### PR TITLE
Only run OpenAPI schema generator on main

### DIFF
--- a/.github/workflows/openapi_gh_pages.yaml
+++ b/.github/workflows/openapi_gh_pages.yaml
@@ -1,8 +1,5 @@
 name: Publish OpenAPI on GitHub Pages
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ poetry install
 poetry run uvicorn hi_api.main:app --reload
 ```
 
+## View OpenAPI schema for the server
+
+A HTML view of the OpenAPI schema matching the `main` branch is viewable at
+[canonical.github.io/hardware-api](https://canonical.github.io/hardware-api)
+
 ## Build and run the reference CLI tool (`hwctl`)
 
 ```bash


### PR DESCRIPTION
- Only run the OpenAPI schema generator on main branch
- Add a README entry for the existence of the OpenAPI HTML view