### PR TITLE
Adds a starter for a snapcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 dist
 cargo-checksum.json
+*.snap

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 The repo contains the API server and client for retrieving hardware information.
 
-
 ## Prerequisites for Deploying Locally
 
-* `poetry` vesion 1.6.1 or later for servier deployment (https://python-poetry.org/docs/)
-* `rust` and `cargo` for client deployment (https://www.rust-lang.org/tools/install)
-
+- `poetry` vesion 1.6.1 or later for servier deployment
+  (https://python-poetry.org/docs/)
+- `rust` and `cargo` for client deployment
+  (https://www.rust-lang.org/tools/install)
 
 ## Running API Server
 
@@ -20,33 +20,40 @@ $ poetry run uvicorn hwapi.main:app --reload
 
 Then you can access the server via this URL: http://127.0.0.1:8000
 
-For information regarding accessing the API schema, read [server README](./server/README.md)
-
+For information regarding accessing the API schema, read
+[server README](./server/README.md)
 
 ## Accessing API schema
 
 You can retrieve API schema in HTML, YAML, and JSON formats:
 
-- To access the HTML view for the API schema, just run the server and follow the [/#docs](http://127.0.0.1:8000/#docs) endpoint.
-- A self-contained HTML representation of the schema is also included in the repository: [openapi.html](./server/schemas/openapi.html).
-- Retrieve the schema in YAML from the running service by following the [/openapi.yaml](http://127.0.0.1:8000/v1/openapi.yaml) endpoint
-- A copy of the [openapi.yaml](./server/schemas/openapi.yaml) is included in the repo, and it is enforced by a CI automation to be up to date.
-- For getting its JSON version, follow the [/openapi.json](http://127.0.0.1:8000/openapi.json) endpoint.
-
+- To access the HTML view for the API schema, just run the server and follow the
+  [/#docs](http://127.0.0.1:8000/#docs) endpoint.
+- A self-contained HTML representation of the schema is also included in the
+  repository: [openapi.html](./server/schemas/openapi.html).
+- Retrieve the schema in YAML from the running service by following the
+  [/openapi.yaml](http://127.0.0.1:8000/v1/openapi.yaml) endpoint
+- A copy of the [openapi.yaml](./server/schemas/openapi.yaml) is included in the
+  repo, and it is enforced by a CI automation to be up to date.
+- For getting its JSON version, follow the
+  [/openapi.json](http://127.0.0.1:8000/openapi.json) endpoint.
 
 ## Build the library (`hwlib`)
 
-For now, the library contains the function to return a sample certification status. It depends on the environment variable `CERTIFICATION_STATUS` and accepts the following values:
+For now, the library contains the function to return a sample certification
+status. It depends on the environment variable `CERTIFICATION_STATUS` and
+accepts the following values:
 
-* `0`: The system has not been seen (default behaviour even if the env variable is not defined).
-* `1`: The system is partially certified (we haven't seen this specific system, but some of its hardware components have been tested on other systems).
-* `2`: This system has been certified (but probably for other Ubuntu release).
+- `0`: The system has not been seen (default behaviour even if the env variable
+  is not defined).
+- `1`: The system is partially certified (we haven't seen this specific system,
+  but some of its hardware components have been tested on other systems).
+- `2`: This system has been certified (but probably for other Ubuntu release).
 
 ```bash
 $ cd client/hwlib
 $ cargo build
 ```
-
 
 ## Build and Run the Reference CLI Tool (`hwctl`)
 
@@ -87,4 +94,14 @@ Certified(
         },
     },
 )
+```
+
+## Building `hwctl` snap
+
+To build and install `hwctl` as a snap locally, do the following after
+[installing snapcraft and a build provider for it](https://snapcraft.io/docs/snapcraft-setup):
+
+```bash
+snapcraft --bind-ssh # --verbose
+sudo snap install ./hwctl_[version].snap --dangerous
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 The repo contains the API server and client for retrieving hardware information.
 
+
 ## Prerequisites for Deploying Locally
 
-- `poetry` vesion 1.6.1 or later for servier deployment
-  (https://python-poetry.org/docs/)
-- `rust` and `cargo` for client deployment
-  (https://www.rust-lang.org/tools/install)
+* `poetry` vesion 1.6.1 or later for servier deployment (https://python-poetry.org/docs/)
+* `rust` and `cargo` for client deployment (https://www.rust-lang.org/tools/install)
+
 
 ## Running API Server
 
@@ -20,40 +20,33 @@ $ poetry run uvicorn hwapi.main:app --reload
 
 Then you can access the server via this URL: http://127.0.0.1:8000
 
-For information regarding accessing the API schema, read
-[server README](./server/README.md)
+For information regarding accessing the API schema, read [server README](./server/README.md)
+
 
 ## Accessing API schema
 
 You can retrieve API schema in HTML, YAML, and JSON formats:
 
-- To access the HTML view for the API schema, just run the server and follow the
-  [/#docs](http://127.0.0.1:8000/#docs) endpoint.
-- A self-contained HTML representation of the schema is also included in the
-  repository: [openapi.html](./server/schemas/openapi.html).
-- Retrieve the schema in YAML from the running service by following the
-  [/openapi.yaml](http://127.0.0.1:8000/v1/openapi.yaml) endpoint
-- A copy of the [openapi.yaml](./server/schemas/openapi.yaml) is included in the
-  repo, and it is enforced by a CI automation to be up to date.
-- For getting its JSON version, follow the
-  [/openapi.json](http://127.0.0.1:8000/openapi.json) endpoint.
+- To access the HTML view for the API schema, just run the server and follow the [/#docs](http://127.0.0.1:8000/#docs) endpoint.
+- A self-contained HTML representation of the schema is also included in the repository: [openapi.html](./server/schemas/openapi.html).
+- Retrieve the schema in YAML from the running service by following the [/openapi.yaml](http://127.0.0.1:8000/v1/openapi.yaml) endpoint
+- A copy of the [openapi.yaml](./server/schemas/openapi.yaml) is included in the repo, and it is enforced by a CI automation to be up to date.
+- For getting its JSON version, follow the [/openapi.json](http://127.0.0.1:8000/openapi.json) endpoint.
+
 
 ## Build the library (`hwlib`)
 
-For now, the library contains the function to return a sample certification
-status. It depends on the environment variable `CERTIFICATION_STATUS` and
-accepts the following values:
+For now, the library contains the function to return a sample certification status. It depends on the environment variable `CERTIFICATION_STATUS` and accepts the following values:
 
-- `0`: The system has not been seen (default behaviour even if the env variable
-  is not defined).
-- `1`: The system is partially certified (we haven't seen this specific system,
-  but some of its hardware components have been tested on other systems).
-- `2`: This system has been certified (but probably for other Ubuntu release).
+* `0`: The system has not been seen (default behaviour even if the env variable is not defined).
+* `1`: The system is partially certified (we haven't seen this specific system, but some of its hardware components have been tested on other systems).
+* `2`: This system has been certified (but probably for other Ubuntu release).
 
 ```bash
 $ cd client/hwlib
 $ cargo build
 ```
+
 
 ## Build and Run the Reference CLI Tool (`hwctl`)
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ version: '0.1' # rewritten with the help of `adopt-info` below
 adopt-info: hwctl
 summary: Hardware API client
 description: Canonical Certified Hardware API client
-  
+
 grade: stable
 confinement: strict
 
@@ -30,6 +30,6 @@ parts:
     override-pull: |
       craftctl default
       # uncomment once there are tags that correspond to version
-      # last_committed_tag="$(git describe --tags --abbrev=0)"
-      # last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
-      # craftctl set version="$(git describe --tags | sed 's/v//')"
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      craftctl set version="$(git describe --tags | sed 's/v//')"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: hwctl
 base: core22
-version: '0.1' # 
+version: '0.1' # rewritten with the help of `adopt-info` below
 adopt-info: hwctl
 summary: Hardware API client
 description: Canonical Certified Hardware API client

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: hwctl
+base: core22
+version: '0.1' # 
+adopt-info: hwctl
+summary: Hardware API client
+description: Canonical Certified Hardware API client
+  
+grade: stable
+confinement: strict
+
+apps:
+  hwctl:
+    command: hwctl
+    plugs:
+      - network
+      - hardware-observe
+      - system-observe
+      - network-setup-observe
+      - kernel-module-observe
+      - hardware-control
+
+parts:
+  hwctl:
+    plugin: rust
+    source: git@github.com:canonical/hardware-api.git
+    source-type: git
+    build-packages:
+      - pkg-config
+      - libssl-dev
+    override-pull: |
+      craftctl default
+      # uncomment once there are tags that correspond to version
+      # last_committed_tag="$(git describe --tags --abbrev=0)"
+      # last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      # craftctl set version="$(git describe --tags | sed 's/v//')"


### PR DESCRIPTION
Adds a snap build configuration with at least some of the right interface requirements that will be needed.

Based on (very) cursory testing of the following kind, Works On My Machine:

```bash
❯ hwctl
NotSeen(
    NotSeenResponse {
        status: "Not Seen",
    },
)
```