### PR TITLE
Fix: remove top key from the hwlib response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,33 +118,31 @@ This is the output you should get running the commands above:
 
 ```bash
     Finished dev [unoptimized + debuginfo] target(s) in 2.00s
-Certified(
-    CertifiedResponse {
-        status: "Certified",
-        os: OS {
-            distributor: "Ubuntu",
-            description: "Ubuntu 20.04.1 LTS",
-            version: "20.04",
-            codename: "focal",
-            kernel: KernelPackage {
-                name: "Linux",
-                version: "5.4.0-42-generic",
-                signature: "Sample Signature",
-            },
-            loaded_modules: [
-                "module1",
-                "module2",
-            ],
-        },
-        bios: Bios {
-            firmware_revision: "1.0",
-            release_date: "2020-01-01",
-            revision: "rev1",
-            vendor: "BIOSVendor",
-            version: "v1.0",
-        },
+Object {
+    "bios": Object {
+        "firmware_revision": String("1.0"),
+        "release_date": String("2020-01-01"),
+        "revision": String("rev1"),
+        "vendor": String("BIOSVendor"),
+        "version": String("v1.0"),
     },
-)
+    "os": Object {
+        "codename": String("focal"),
+        "description": String("Ubuntu 20.04.1 LTS"),
+        "distributor": String("Ubuntu"),
+        "kernel": Object {
+            "name": String("Linux"),
+            "signature": String("Sample Signature"),
+            "version": String("5.4.0-42-generic"),
+        },
+        "loaded_modules": Array [
+            String("module1"),
+            String("module2"),
+        ],
+        "version": String("20.04"),
+    },
+    "status": String("Certified"),
+}
 ```
 
 ## Building `hwctl` snap

--- a/client/README.md
+++ b/client/README.md
@@ -28,11 +28,11 @@ Now you can use the lib in your Python code:
 ```python
 >>> import hwlib
 >>> hwlib.get_certification_status("https://example.com")
-{'NotSeen':{'status':'Not Seen'}}
+{'status':'Not Seen'}
 >>> import os
 >>> os.environ["CERTIFICATION_STATUS"] = "2"
 >>> hwlib.get_certification_status("https://example.com")
-{'Certified': {'status': 'Certified', 'os': {'distributor': 'Ubuntu', 'description': 'Ubuntu 20.04.1 LTS', 'version': '20.04', 'codename': 'focal', 'kernel': {'name': 'Linux', 'version': '5.4.0-42-generic', 'signature': 'Sample Signature'}, 'loaded_modules': ['module1', 'module2']}, 'bios': {'firmware_revision': '1.0', 'release_date': '2020-01-01', 'revision': 'rev1', 'vendor': 'BIOSVendor', 'version': 'v1.0'}}}
+{'bios': {'firmware_revision': '1.0', 'release_date': '2020-01-01', 'revision': 'rev1', 'vendor': 'BIOSVendor', 'version': 'v1.0'}, 'os': {'codename': 'focal', 'description': 'Ubuntu 20.04.1 LTS', 'distributor': 'Ubuntu', 'kernel': {'name': 'Linux', 'signature': 'Sample Signature', 'version': '5.4.0-42-generic'}, 'loaded_modules': ['module1', 'module2'], 'version': '20.04'}, 'status': 'Certified'}
 ```
 
 

--- a/client/hwlib/src/lib.rs
+++ b/client/hwlib/src/lib.rs
@@ -22,10 +22,7 @@
 pub mod models;
 pub mod py_bindings;
 use models::devices;
-use models::rbody::{
-    CertificationStatusResponse, CertifiedResponse, NotSeenResponse,
-    RelatedCertifiedSystemExistsResponse,
-};
+use models::rbody::{CertifiedResponse, RelatedCertifiedSystemExistsResponse};
 use models::software;
 
 fn get_certified_system_sample() -> CertifiedResponse {
@@ -112,22 +109,17 @@ fn get_related_certified_system_exists_sample() -> RelatedCertifiedSystemExistsR
     }
 }
 
-pub async fn get_certification_status(
-    _url: &str,
-) -> Result<CertificationStatusResponse, reqwest::Error> {
+pub async fn get_certification_status(_url: &str) -> Result<serde_json::Value, reqwest::Error> {
     let response_type = std::env::var("CERTIFICATION_STATUS")
         .unwrap_or_else(|_| "0".to_string())
         .parse::<i32>()
         .unwrap_or(0);
 
     let response = match response_type {
-        1 => CertificationStatusResponse::RelatedCertifiedSystemExists(
-            get_related_certified_system_exists_sample(),
-        ),
-        2 => CertificationStatusResponse::Certified(get_certified_system_sample()),
-        _ => CertificationStatusResponse::NotSeen(NotSeenResponse {
-            status: "Not Seen".to_string(),
-        }),
+        1 => serde_json::json!(get_related_certified_system_exists_sample()),
+        2 => serde_json::json!(get_certified_system_sample()),
+        _ => serde_json::json!({"status": "Not Seen"}),
     };
+
     Ok(response)
 }

--- a/client/hwlib/src/py_bindings.rs
+++ b/client/hwlib/src/py_bindings.rs
@@ -20,10 +20,11 @@
 
 use crate::get_certification_status as native_get_certification_status;
 use once_cell::sync::Lazy;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-
+use pyo3::types::PyString;
 use pyo3::wrap_pyfunction;
-use pyo3::PyResult;
+use pyo3::{PyObject, PyResult, Python};
 use tokio::runtime::Runtime;
 
 static RT: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("Failed to create Tokio runtime"));
@@ -33,21 +34,15 @@ fn get_certification_status(py: Python, url: String) -> PyResult<PyObject> {
     let response = RT.block_on(async { native_get_certification_status(&url).await });
 
     match response {
-        Ok(response_struct) => {
-            let json_str = serde_json::to_string(&response_struct).map_err(|e| {
-                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Failed to serialize response: {}",
-                    e
-                ))
-            })?;
-
-            let json: PyObject = pyo3::types::PyString::new(py, &json_str).into();
+        Ok(response_value) => {
+            let json_str = response_value.to_string();
+            let json: PyObject = PyString::new(py, &json_str).into();
             let json_module = py.import("json")?;
             let json_object: PyObject = json_module.call_method1("loads", (json,))?.into();
 
             Ok(json_object)
         }
-        Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+        Err(e) => Err(PyErr::new::<PyRuntimeError, _>(format!(
             "Request failed: {}",
             e
         ))),

--- a/client/hwlib/tests/test_cert_status.rs
+++ b/client/hwlib/tests/test_cert_status.rs
@@ -1,5 +1,4 @@
 use hwlib::get_certification_status;
-use hwlib::models::rbody::CertificationStatusResponse;
 
 const SERVER_URL: &str = "https://example.com";
 
@@ -7,7 +6,7 @@ const SERVER_URL: &str = "https://example.com";
 async fn test_get_certification_status_not_seen() {
     std::env::set_var("CERTIFICATION_STATUS", "0");
     let response = get_certification_status(SERVER_URL).await.unwrap();
-    assert!(matches!(response, CertificationStatusResponse::NotSeen(_)));
+    assert_eq!(response.get("status").unwrap(), "Not Seen");
     std::env::remove_var("CERTIFICATION_STATUS");
 }
 
@@ -15,10 +14,8 @@ async fn test_get_certification_status_not_seen() {
 async fn test_get_certification_status_partially_certified() {
     std::env::set_var("CERTIFICATION_STATUS", "1");
     let response = get_certification_status(SERVER_URL).await.unwrap();
-    assert!(matches!(
-        response,
-        CertificationStatusResponse::RelatedCertifiedSystemExists(_)
-    ));
+    assert!(response.get("board").is_some());
+    assert_eq!(response.get("status").unwrap(), "Partially Certified");
     std::env::remove_var("CERTIFICATION_STATUS");
 }
 
@@ -26,9 +23,8 @@ async fn test_get_certification_status_partially_certified() {
 async fn test_get_certification_status_certified() {
     std::env::set_var("CERTIFICATION_STATUS", "2");
     let response = get_certification_status(SERVER_URL).await.unwrap();
-    assert!(matches!(
-        response,
-        CertificationStatusResponse::Certified(_)
-    ));
+    assert_eq!(response.get("status").unwrap(), "Certified");
+    assert!(response.get("os").is_some());
+    assert!(response.get("bios").is_some());
     std::env::remove_var("CERTIFICATION_STATUS");
 }

--- a/client/hwlib/tox.ini
+++ b/client/hwlib/tox.ini
@@ -6,6 +6,7 @@ skipsdist = true
 [testenv]
 deps =
     black
+    ruff
     pytest
     pytest-asyncio
     maturin
@@ -13,4 +14,5 @@ commands_pre =
     {envbindir}/maturin develop
 commands =
     {envbindir}/python -m black --check pytests/
+    {envbindir}/python -m ruff check pytests/
     {envbindir}/python -m pytest pytests/


### PR DESCRIPTION
This PR just removed the top-key like "Certified" or "Not seen" from the client response and outputs the value itself
So, instead of having `{'NotSeen':{'status':'Not Seen'}}`, we just get `{'status':'Not Seen'}`

The tests for both client and python bindings were updated as well