### PR TITLE
Add progress bar for C3 importing module

### DIFF
--- a/server/hwapi/external/c3/helpers.py
+++ b/server/hwapi/external/c3/helpers.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Canonical Ltd.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Written by:
+#        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
+
+
+def progress_bar(it: int, total: int):
+    """
+    Print progress BAR as percentage of it out of total
+
+    :it: the current number of items
+    :total: the total number of items
+    """
+    fillwith = "#"
+    dec = 2
+    leng = 50
+    percent = f"{100 * (it / total):.{dec}f}"
+    fill_length = int(leng * it // total)
+    prog_bar = fillwith * fill_length + "-" * (leng - fill_length)
+    print(f"\rProgress |{prog_bar}| {percent}% Complete", end="\r")


### PR DESCRIPTION
This PR adds the progress bar to be printed while data is loaded from C3 to make it more user-friendly.

Here is an example of how it looks:
![image](https://github.com/canonical/hardware-api/assets/84857215/e05ef191-2a06-4826-a579-643128192471)

![image](https://github.com/canonical/hardware-api/assets/84857215/bd753dda-f2a1-4614-85c1-033df5c42be0)
