### PR TITLE
Rebuild the OCI and Charm periodically

### DIFF
--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -5,6 +5,8 @@ on:
       - "server/**"
       - ".github/workflows/publish_server.yml"
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Rebuild every Sunday at 00:00
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Not sure if we want this just yet, but it might be good to start testing it and I don't see a downside to doing it now. This will periodically rebuild the hardware-api OCI image and charm on a schedule (weekly for now, can increase later easily if we want).  When rebuilding it, we should also get the latest c3 data in the sqlite db