### PR TITLE
Fix lintian errors and update package version

### DIFF
--- a/.github/workflows/test_hwlib_debian_build.yaml
+++ b/.github/workflows/test_hwlib_debian_build.yaml
@@ -55,6 +55,7 @@ jobs:
     - name: Generate checksums
       run: ./debian/generate_checksums.py
     - run: dpkg-buildpackage -us -uc -S
+    - run: lintian --pedantic --verbose
     - name: Setup sbuild and build the package
       run: |
         set -xeu

--- a/client/README.md
+++ b/client/README.md
@@ -100,7 +100,7 @@ dch -i  # increment release number
 dch -r  # create release
 ```
 
-Then you need to vendor the Rust depepndencies:
+Then you need to vendor the Rust dependencies:
 
 ```bash
 # under client/hwlib/ dir
@@ -121,6 +121,7 @@ Then, build the source package:
 dpkg-buildpackage -S #-k=<key-to-sign> if you have more than one GPG key for the specified DEBEMAIL
 ```
 
+You can also `lintian --pedantic` to staticly check the files under the `debian/` dir.
 
 ### Testing your package
 

--- a/client/hwlib/debian/changelog
+++ b/client/hwlib/debian/changelog
@@ -1,4 +1,4 @@
-rust-hwlib (0.0.1) focal; urgency=medium
+rust-hwlib (0.0.1~ppa1) focal; urgency=medium
 
   * Publish the initial version of the hwlib for focal
 

--- a/client/hwlib/debian/changelog
+++ b/client/hwlib/debian/changelog
@@ -1,3 +1,9 @@
+rust-hwlib (0.0.1~ppa2) focal; urgency=medium
+
+  * Fix lintian errors and warnings
+
+ -- Nadzeya Hutsko <nadzeya.hutsko@canonical.com>  Mon, 08 Jul 2024 17:14:10 +0300
+
 rust-hwlib (0.0.1~ppa1) focal; urgency=medium
 
   * Publish the initial version of the hwlib for focal

--- a/client/hwlib/debian/control
+++ b/client/hwlib/debian/control
@@ -6,8 +6,8 @@ Build-Depends: debhelper (>= 12),
                cargo:native,
                rustc:native,
                libssl-dev,
-               pkg-config
-Maintainer: Canonical Hardware Certification <canonical-hw-cert@lists.launchpad.net> 
+               pkgconf
+Maintainer: Canonical Hardware Certification <canonical-hw-cert@lists.launchpad.net>
 Uploaders: Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 Standards-Version: 4.6.2
 Vcs-Git: https://github.com/canonical/hardware-api.git [client/hwlib/src]

--- a/client/hwlib/debian/copyright
+++ b/client/hwlib/debian/copyright
@@ -1,9 +1,11 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: librust-hwlib-dev
 Source: https://github.com/canonical/hardware-api/tree/main/client/hwlib
 
 Files: *
 Copyright: Copyright 2024 Canonical Ltd.
+License: GPL-3
+
 License: GPL-3
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License version 3,
@@ -19,4 +21,3 @@ License: GPL-3
  .
  On Debian-based systems the full text of the GPL, version 3, can be found at
  /usr/share/common-licenses/GPL-3.
-

--- a/client/hwlib/debian/watch
+++ b/client/hwlib/debian/watch
@@ -1,4 +1,0 @@
-version=4
-opts=filenamemangle=s/.*\/(.*)\/download/hwlib-$1\.tar\.gz/g,\
-uversionmangle=s/(\d)[_\.\-\+]?((RC|rc|pre|dev|beta|alpha)\d*)$/$1~$2/ \
-https://qa.debian.org/cgi-bin/fakeupstream.cgi?upstream=crates.io/hwlib .*/crates/hwlib/@ANY_VERSION@/download


### PR DESCRIPTION
This PR fixes the warnings generated by `lintian`, which is a required stage before creating the MIR bug (see more: https://github.com/canonical/ubuntu-mir?tab=readme-ov-file#main-inclusion-requirements)

It also updates the CI job to include the lintian check.

Also, as it was recommended in the [~hardware-api MM thread](https://chat.canonical.com/canonical/pl/sxnnnndodinqfkdcrco6sb8y7a), the version has been changed to `0.0.1~ppa1` (and updated to `~ppa2`) to preserve the “clean” version for publishing it to the archive after getting approval