### PR TITLE
Update changelog and related files to publishing for oracular

### DIFF
--- a/.github/workflows/test_hwlib_debian_build.yaml
+++ b/.github/workflows/test_hwlib_debian_build.yaml
@@ -61,7 +61,7 @@ jobs:
         set -xeu
         mkdir -p ~/.cache/sbuild
         echo
-        mmdebstrap --variant=buildd --components=main,restricted,universe focal ~/.cache/sbuild/focal-amd64.tar.zst
+        mmdebstrap --variant=buildd --components=main,restricted,universe oracular ~/.cache/sbuild/oracular-amd64.tar.zst
 
         echo "Running sbuild-debian-developer-setup"
         sudo sbuild-debian-developer-setup
@@ -83,4 +83,4 @@ jobs:
           exit 1
         fi
         echo "Running sbuild for $PACKAGE_DSC"
-        sbuild $PACKAGE_DSC -d focal -v
+        sbuild $PACKAGE_DSC -d oracular -v

--- a/client/README.md
+++ b/client/README.md
@@ -126,12 +126,12 @@ You can also `lintian --pedantic` to staticly check the files under the `debian/
 ### Testing your package
 
 You can test your package and build it with the [sbuild](https://wiki.debian.org/sbuild) tool.
-In this example, we do it for focal distro, but you can replace it with the desired one:
+In this example, we do it for oracular distro, but you can replace it with the desired one:
 
 ```bash
 sudo apt install sbuild mmdebstrap uidmap
 mkdir -p ~/.cache/sbuild
-mmdebstrap --variant=buildd --components=main,restricted,universe focal ~/.cache/sbuild/focal-amd64.tar.zst
+mmdebstrap --variant=buildd --components=main,restricted,universe oracular ~/.cache/sbuild/oracular-amd64.tar.zst
 ```
 
 For configuring `sbuild` , install `sbuild-debian-developer-setup`:
@@ -161,7 +161,7 @@ $autopkgtest_opts = [ '--apt-upgrade', '--', 'unshare', '--release', '%r', '--ar
 Not you can build the binary itself:
 
 ```bash
-sbuild /path/to/.dsc -d focal
+sbuild /path/to/.dsc -d oracular
 ```
 
 After that, you can publish the package by rinning:

--- a/client/hwlib/debian/changelog
+++ b/client/hwlib/debian/changelog
@@ -1,11 +1,5 @@
-rust-hwlib (0.0.1~ppa2) focal; urgency=medium
+rust-hwlib (0.0.1~ppa1) oracular; urgency=medium
 
-  * Fix lintian errors and warnings
+  * Publish the initial version of the hwlib for oracular
 
- -- Nadzeya Hutsko <nadzeya.hutsko@canonical.com>  Mon, 08 Jul 2024 17:14:10 +0300
-
-rust-hwlib (0.0.1~ppa1) focal; urgency=medium
-
-  * Publish the initial version of the hwlib for focal
-
- -- Nadzeya Hutsko <nadzeya.hutsko@canonical.com>  Thu, 04 Jul 2024 13:01:54 +0300
+ -- Nadzeya Hutsko <nadzeya.hutsko@canonical.com>  Tue, 09 Jul 2024 15:10:14 +0300

--- a/client/hwlib/debian/vendor-rust.sh
+++ b/client/hwlib/debian/vendor-rust.sh
@@ -15,14 +15,20 @@ cargo vendor-filterer "$CARGO_VENDOR_DIR"
 # Delete .sh files in the vendor/vcpkg directory if it exists
 if [ -d "$CARGO_VENDOR_DIR/vcpkg" ]; then
     find "$CARGO_VENDOR_DIR/vcpkg" -name "*.sh" -exec rm -f {} +
+    # Remove checksums for the deleted *.sh files that are not used by the code but generate lintian errors
+    for json_file in $(find "${CARGO_VENDOR_DIR}/vcpkg" -name ".cargo-checksum.json"); do
+        tmp_file=$(mktemp)
+        jq '.files |= with_entries(select(.key | endswith(".sh") | not))' "$json_file" > "$tmp_file"
+        mv "$tmp_file" "$json_file"
+    done
 fi
 
 # Some crates are shipped with .a files, which get removed by the helpers during the package build as a safety measure.
-# This results in cargo failing to compile, since the files (which are listed in the checksums) are not there anymore. For those crates, we need to remove their checksums.
-# Also, here we remove checksums for the deleted *.sh files that are not used by the code but generate lintian errors
+# This results in cargo failing to compile, since the files (which are listed in the checksums) are not there anymore.
+# For those crates, we need to remove their checksums
 for json_file in $(find "$CARGO_VENDOR_DIR" -name ".cargo-checksum.json"); do
     tmp_file=$(mktemp)
-    jq '.files |= with_entries(select(.key | endswith(".a") | not) | select(.key | endswith(".sh") | not))' "$json_file" > "$tmp_file"
+    jq '.files |= with_entries(select(.key | endswith(".a") | not))' "$json_file" > "$tmp_file"
     mv "$tmp_file" "$json_file"
 done
 

--- a/client/hwlib/debian/vendor-rust.sh
+++ b/client/hwlib/debian/vendor-rust.sh
@@ -12,12 +12,17 @@ fi
 
 cargo vendor-filterer "$CARGO_VENDOR_DIR"
 
+# Delete .sh files in the vendor/vcpkg directory if it exists
+if [ -d "$CARGO_VENDOR_DIR/vcpkg" ]; then
+    find "$CARGO_VENDOR_DIR/vcpkg" -name "*.sh" -exec rm -f {} +
+fi
+
 # Some crates are shipped with .a files, which get removed by the helpers during the package build as a safety measure.
-# This results in cargo failing to compile, since the files (which are listed in the checksums) are not there anymore.
-# For those crates, we need to remove their checksums
+# This results in cargo failing to compile, since the files (which are listed in the checksums) are not there anymore. For those crates, we need to remove their checksums.
+# Also, here we remove checksums for the deleted *.sh files that are not used by the code but generate lintian errors
 for json_file in $(find "$CARGO_VENDOR_DIR" -name ".cargo-checksum.json"); do
     tmp_file=$(mktemp)
-    jq '.files |= with_entries(select(.key | endswith(".a") | not))' "$json_file" > "$tmp_file"
+    jq '.files |= with_entries(select(.key | endswith(".a") | not) | select(.key | endswith(".sh") | not))' "$json_file" > "$tmp_file"
     mv "$tmp_file" "$json_file"
 done
 


### PR DESCRIPTION
This PR updates the changelog, CI job, and readme to use oracular distro instead of focal.
The current PPA where the lib is published will be wiped up, so that's why the changelog is modified instead of being updates

For noble, jammy, and focal, we'll use backporting. Here you can see an example of how I've tested it in a test PPA: https://launchpad.net/~nhutsko/+archive/ubuntu/ppa/+packages?field.name_filter=rust&field.status_filter=published&field.series_filter=

Also, I've updated the `vendor_rust.sh` script to exclude the shell scripts from the `vendor/vcpkg` libraries. We don't use these scripts in our code and don't depend on it, but they generate lintian errors because of the incorrect bash syntax