### PR TITLE
Drop threading in the c3 client logic

### DIFF
--- a/server/hwapi/external/c3/client.py
+++ b/server/hwapi/external/c3/client.py
@@ -20,7 +20,7 @@
 
 import requests
 import logging
-from typing import Callable, Type, Any
+from typing import Callable, Type
 from pydantic import BaseModel
 
 from sqlite3 import IntegrityError as SQLite3IntegrityError

--- a/server/hwapi/external/c3/helpers.py
+++ b/server/hwapi/external/c3/helpers.py
@@ -25,8 +25,8 @@ def progress_bar(it: int, total: int):
     :it: the current number of items
     :total: the total number of items
     """
-    fillwith = "█"
-    dec = 2
+    fillwith = "#"
+    dec = 1
     leng = 50
     percent = f"{100 * (it / total):.{dec}f}"
     fill_length = int(leng * it // total)


### PR DESCRIPTION
It turned out that C3 cannot handle so many frequent requests in a row and starts returning 500 error, I've decided to drop the threading solution and revert the script logic

Also, to avoid printing the progress bar with the same output multiple times, I've updated the script to print it only when the percentage changes, and change it to print only one digit after the decimal point.