### PR TITLE
Update timeout for publish_server action

### DIFF
--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -17,10 +17,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     env:
       IMAGE_NAME: ${{ github.repository }}/hwapi
-
+    timeout-minutes: 600 # 10 hours
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -28,23 +27,19 @@ jobs:
           config-inline: |
             [registry."docker.io"]
               mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
-
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Build and push backend Docker image
         uses: docker/build-push-action@v6
         with:
@@ -57,11 +52,9 @@ jobs:
   build-and-push-charm:
     runs-on: [self-hosted, linux, xlarge, jammy, x64]
     needs: build-and-push-image
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:


### PR DESCRIPTION
This PR simply increases the timeout for the publish_server job to 10 hours instead of the default 6 hours

I've used this checkbox job as a reference: https://github.com/canonical/checkbox/blob/main/.github/workflows/deb-daily-builds.yml#L18