### PR TITLE
Remove \r sign at the print end in progress bar

### DIFF
--- a/server/hwapi/external/c3/helpers.py
+++ b/server/hwapi/external/c3/helpers.py
@@ -31,4 +31,4 @@ def progress_bar(it: int, total: int):
     percent = f"{100 * (it / total):.{dec}f}"
     fill_length = int(leng * it // total)
     prog_bar = fillwith * fill_length + "-" * (leng - fill_length)
-    print(f"\rProgress |{prog_bar}| {percent}% Complete", end="\r")
+    print(f"\rProgress |{prog_bar}| {percent}% Complete", end="")


### PR DESCRIPTION
Currently, we use `end='\r'` at the end of the print statement when printing progress bar during importing data from C3
However, it doesn't behave as expected in GH actions:
![image](https://github.com/user-attachments/assets/80e7550f-a150-4c0e-a8dd-f4265946717d)

I've found out that replacing it with `end=""` can help: https://github.com/jupyterlab/jupyterlab/issues/5326#issuecomment-442029859 (I hope it'll work for GH actions as well, because this approach is recommended for other tools)