### PR TITLE
Specify cargo version deb pack

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -240,7 +240,7 @@ autopkgtest-build-lxd ubuntu-daily:plucky/amd64
 Then run the autopkgtests in `lxd`:
 
 ```sh
-autopkgtest . -- lxd autopkgtest/ubuntu/plucky/amd64
+autopkgtest /path/to/<package>_<version>_source.changes -- lxd autopkgtest/ubuntu/plucky/amd64
 ```
 
 ### Publishing the package

--- a/client/debian/control
+++ b/client/debian/control
@@ -1,7 +1,7 @@
 Source: rust-hwlib
 Section: rust
 Priority: optional
-Build-Depends: cargo:native,
+Build-Depends: cargo:native (>= 1.75),
                debhelper (>= 12),
                dh-cargo (>= 23),
                jq,


### PR DESCRIPTION
This PR specifies `cargo` version in `debian/control` to be at least `1.75`, so auto-package tests pass for all the supported distributions.
It also updates the instructions on how to run these tests locally