### PR TITLE
In hwctl command, don't output the request information

### DIFF
--- a/client/debian/changelog
+++ b/client/debian/changelog
@@ -1,3 +1,9 @@
+rust-hwlib (0.9.0~ppa3) plucky; urgency=medium
+
+  * Don't output the request information in hwctl.
+
+ -- Nadzeya Hutsko <nadzeya.hutsko@canonical.com>  Mon, 17 Feb 2025 12:50:15 +0100
+
 rust-hwlib (0.9.0~ppa2) plucky; urgency=medium
 
   * Update cargo dependencies.

--- a/client/hwctl/src/main.rs
+++ b/client/hwctl/src/main.rs
@@ -40,10 +40,6 @@ async fn run() -> Result<()> {
     let cert_status_request =
         CertificationStatusRequest::new(Paths::default()).context("cannot collect system data")?;
 
-    let request_json = serde_json::to_string_pretty(&cert_status_request)
-        .context("cannot serialize request as JSON")?;
-    println!("Request:\n{}", request_json);
-
     let url = env::var("HW_API_URL").unwrap_or_else(|_| String::from("https://hw.ubuntu.com"));
     let response = send_certification_status_request(url, &cert_status_request)
         .await
@@ -51,7 +47,7 @@ async fn run() -> Result<()> {
 
     let response_json =
         serde_json::to_string_pretty(&response).context("cannot serialize response as JSON")?;
-    println!("\nResponse:\n{}", response_json);
+    println!("{}", response_json);
 
     Ok(())
 }


### PR DESCRIPTION
Since a user is interested only in the status information, we should avoid outputting the request information.