### PR TITLE
[DRAFT] Replace dpkg with Rust ARCH const

### DIFF
--- a/client/hwlib/src/constants.rs
+++ b/client/hwlib/src/constants.rs
@@ -23,6 +23,5 @@ pub const PROC_CPUINFO_FILE_PATH: &str = "/proc/cpuinfo";
 pub const PROC_DEVICE_TREE_DIR_PATH: &str = "/proc/device-tree/";
 pub const PROC_VERSION_FILE_PATH: &str = "/proc/version";
 
-pub const DPKG: &str = "/usr/bin/dpkg";
 pub const LSB_RELEASE: &str = "/usr/bin/lsb_release";
 pub const LSMOD: &str = "/usr/bin/lsmod";

--- a/client/hwlib/src/models/request_validators.rs
+++ b/client/hwlib/src/models/request_validators.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use crate::{
     collectors::{
         hardware_info::{table_load_from_device, SystemInfo},
-        os_info::{get_architecture, CommandRunner, SystemCommandRunner},
+        os_info::{get_deb_arch, CommandRunner, SystemCommandRunner},
     },
     constants,
     models::{
@@ -129,7 +129,7 @@ impl CertificationStatusRequest {
         let model = system_info.product_name;
         let vendor = system_info.manufacturer;
 
-        let architecture = get_architecture(runner)?;
+        let architecture = get_deb_arch(std::env::consts::ARCH)?;
         let os = OS::try_new(proc_version_filepath.as_path(), runner)?;
         let pci_peripherals = Vec::new();
         let usb_peripherals = Vec::new();
@@ -158,7 +158,7 @@ impl CertificationStatusRequest {
             ..
         } = paths;
         let cpu_info = CpuInfo::from_file(&cpuinfo_filepath.clone())?;
-        let architecture = get_architecture(runner)?;
+        let architecture = get_deb_arch(std::env::consts::ARCH)?;
         let bios = None;
         let board = Board::try_from(device_tree_dirpath.as_path())?;
         let chassis = None;
@@ -255,7 +255,6 @@ mod tests {
             .collect::<String>();
 
         let mock_calls = vec![
-            ((constants::DPKG, vec!["--print-architecture"]), Ok("amd64")),
             (
                 (constants::LSB_RELEASE, vec!["-c"]),
                 Ok(codename_str.as_str()),


### PR DESCRIPTION
This removes the need for running the `dpkg` command in `hwctl`. Instead, we can use the `ARCH` constant that is provided by Rust.

I have, however, changed the `get_architecture` function to instead convert an arch string to a debian architecture string.