### PR TITLE
Add better error handling for file not found errors

### DIFF
--- a/client/hwlib/src/collectors/cpuinfo.rs
+++ b/client/hwlib/src/collectors/cpuinfo.rs
@@ -42,10 +42,7 @@ impl CpuInfo {
         let mut cores_count = 0;
 
         let raw_cpuinfo = read_to_string(cpuinfo_filepath).with_context(|| {
-            format!(
-                "Failed to read CPU info file: {}",
-                cpuinfo_filepath.display()
-            )
+            format!("cannot read CPU info file {:?}", cpuinfo_filepath.display())
         })?;
 
         for line in raw_cpuinfo.lines() {
@@ -129,7 +126,7 @@ impl CpuFrequency {
             Err(e) if e.kind() == NotFound => Ok(Self::from_m_hz(0)),
             Err(e) => Err(e).with_context(|| {
                 format!(
-                    "Failed to read CPU frequency file: {}",
+                    "cannot read CPU frequency file: {:?}",
                     max_cpu_frequency_filepath.display()
                 )
             }),

--- a/client/hwlib/src/collectors/cpuinfo.rs
+++ b/client/hwlib/src/collectors/cpuinfo.rs
@@ -16,7 +16,7 @@
  *        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
  */
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use itertools::Itertools;
 use std::{collections::HashMap, fs::read_to_string, io::ErrorKind::NotFound, path::Path};
 
@@ -41,7 +41,13 @@ impl CpuInfo {
         let mut attributes: HashMap<&str, &str> = HashMap::new();
         let mut cores_count = 0;
 
-        let raw_cpuinfo = read_to_string(cpuinfo_filepath)?;
+        let raw_cpuinfo = read_to_string(cpuinfo_filepath).with_context(|| {
+            format!(
+                "Failed to read CPU info file: {}",
+                cpuinfo_filepath.display()
+            )
+        })?;
+
         for line in raw_cpuinfo.lines() {
             let trimmed_line = line.trim();
             if trimmed_line.is_empty() {
@@ -121,7 +127,12 @@ impl CpuFrequency {
                 Ok(Self::from_k_hz(k_hz))
             }
             Err(e) if e.kind() == NotFound => Ok(Self::from_m_hz(0)),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(e).with_context(|| {
+                format!(
+                    "Failed to read CPU frequency file: {}",
+                    max_cpu_frequency_filepath.display()
+                )
+            }),
         }
     }
 

--- a/client/hwlib/src/collectors/hardware_info.rs
+++ b/client/hwlib/src/collectors/hardware_info.rs
@@ -186,29 +186,20 @@ pub(crate) fn table_load_from_device(
     table_file: &Path,
 ) -> Result<SMBiosData, anyhow::Error> {
     let version = SMBiosEntryPoint64::try_load_from_file(entry_file)
-        .with_context(|| {
-            format!(
-                "Failed to load SMBIOS entry point 64 from: {}",
-                entry_file.display()
-            )
-        })
+        .with_context(|| format!("cannot load SMBIOS entry from: {:?}", entry_file.display()))
         .map(|entry_point| SMBiosVersion {
             major: entry_point.major_version(),
             minor: entry_point.minor_version(),
             revision: 0,
         })
         .or_else(|err| {
-            // Downcast to std::io::Error to check the kind
             if let Some(io_err) = err.downcast_ref::<IoError>() {
                 if io_err.kind() != ErrorKind::InvalidData {
                     return Err(err);
                 }
                 SMBiosEntryPoint32::try_load_from_file(entry_file)
                     .with_context(|| {
-                        format!(
-                            "Failed to load SMBIOS entry point 32 from: {}",
-                            entry_file.display()
-                        )
+                        format!("cannot load SMBIOS entry from: {:?}", entry_file.display())
                     })
                     .map(|entry_point| SMBiosVersion {
                         major: entry_point.major_version(),
@@ -221,7 +212,7 @@ pub(crate) fn table_load_from_device(
         })?;
 
     SMBiosData::try_load_from_file(table_file.to_str().unwrap(), Some(version))
-        .with_context(|| format!("Failed to load SMBIOS table from: {}", table_file.display()))
+        .with_context(|| format!("cannot load SMBIOS table from: {:?}", table_file.display()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #313 

This PR adds more context for places where we try to read from a file or execute it. If such a file is not found, we provide which file has not been found (it used to be just `File not found` error with no information which file)

This is how it looks when an executable binary is not found

```bash
# Moving the lsb_release file so it's not present
$ sudo mv /usr/bin/lsb_release ./

$ sudo ./target/debug/hwctl
ERROR: cannot collect system data

Caused by:
    0: Failed to get release info using lsb_release -c
    1: No such file or directory (os error 2)
```

Example when SMBIOS data is not available

```
ERROR: cannot collect system data

Caused by:
    0: Failed to load SMBIOS entry point 64 from: /sys/firmware/dmi/tables/smbios_entry_point
    1: Permission denied (os error 13)
```