### PR TITLE
Remove the usage of docker mirror in CI

### DIFF
--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -23,17 +23,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Create Docker config with mirror
-        run: |
-          MIRROR_URL="${DOCKERHUB_MIRROR:-https://github-runner-dockerhub-cache.canonical.com:5000}"
-          mkdir -p ~/.docker
-          echo "{\"registry-mirrors\": [\"${MIRROR_URL}\"]}" > ~/.docker/daemon.json
-          echo '[registry."docker.io"]' > $GITHUB_WORKSPACE/buildkitd.toml
-          echo "  mirrors = [\"${MIRROR_URL}\"]" >> $GITHUB_WORKSPACE/buildkitd.toml
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-config: ${{ github.workspace }}/buildkitd.toml
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -21,14 +21,19 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}/hwapi
     timeout-minutes: 600 # 10 hours
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Create Docker config with mirror
+        run: |
+          MIRROR_URL="${DOCKERHUB_MIRROR:-https://github-runner-dockerhub-cache.canonical.com:5000}"
+          mkdir -p ~/.docker
+          echo "{\"registry-mirrors\": [\"${MIRROR_URL}\"]}" > ~/.docker/daemon.json
+          echo '[registry."docker.io"]' > $GITHUB_WORKSPACE/buildkitd.toml
+          echo "  mirrors = [\"${MIRROR_URL}\"]" >> $GITHUB_WORKSPACE/buildkitd.toml
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          config-inline: |
-            [registry."docker.io"]
-              mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
-      - name: Checkout repository
-        uses: actions/checkout@v4
+          buildkitd-config: ${{ github.workspace }}/buildkitd.toml
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -26,12 +26,17 @@ jobs:
         working-directory: integration-tests
     steps:
     - uses: actions/checkout@v4
+    - name: Create Docker config with mirror
+      run: |
+        MIRROR_URL="${DOCKERHUB_MIRROR:-https://github-runner-dockerhub-cache.canonical.com:5000}"
+        mkdir -p ~/.docker
+        echo "{\"registry-mirrors\": [\"${MIRROR_URL}\"]}" > ~/.docker/daemon.json
+        echo '[registry."docker.io"]' > $GITHUB_WORKSPACE/buildkitd.toml
+        echo "  mirrors = [\"${MIRROR_URL}\"]" >> $GITHUB_WORKSPACE/buildkitd.toml
     - name: Set up docker buildx
       uses: docker/setup-buildx-action@v3
       with:
-        config-inline: |
-          [registry."docker.io"]
-          mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
+        buildkitd-config: ${{ github.workspace }}/buildkitd.toml
     - name: Install docker compose
       run: |
         sudo apt update

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -26,17 +26,6 @@ jobs:
         working-directory: integration-tests
     steps:
     - uses: actions/checkout@v4
-    - name: Create Docker config with mirror
-      run: |
-        MIRROR_URL="${DOCKERHUB_MIRROR:-https://github-runner-dockerhub-cache.canonical.com:5000}"
-        mkdir -p ~/.docker
-        echo "{\"registry-mirrors\": [\"${MIRROR_URL}\"]}" > ~/.docker/daemon.json
-        echo '[registry."docker.io"]' > $GITHUB_WORKSPACE/buildkitd.toml
-        echo "  mirrors = [\"${MIRROR_URL}\"]" >> $GITHUB_WORKSPACE/buildkitd.toml
-    - name: Set up docker buildx
-      uses: docker/setup-buildx-action@v3
-      with:
-        buildkitd-config: ${{ github.workspace }}/buildkitd.toml
     - name: Install docker compose
       run: |
         sudo apt update

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -25,17 +25,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
-      - name: Create Docker config with mirror
-        run: |
-          MIRROR_URL="${DOCKERHUB_MIRROR:-https://github-runner-dockerhub-cache.canonical.com:5000}"
-          mkdir -p ~/.docker
-          echo "{\"registry-mirrors\": [\"${MIRROR_URL}\"]}" > ~/.docker/daemon.json
-          echo '[registry."docker.io"]' > $GITHUB_WORKSPACE/buildkitd.toml
-          echo "  mirrors = [\"${MIRROR_URL}\"]" >> $GITHUB_WORKSPACE/buildkitd.toml
-      - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-config: ${{ github.workspace }}/buildkitd.toml
       - name: Install docker-compose
         run: |
           COMPOSE_URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)"
@@ -43,9 +32,6 @@ jobs:
           sudo curl -L  -L $COMPOSE_URL -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
           echo `docker-compose --version`
-      - name: Set dockerhub registry mirror at /etc/docker/daemon.json
-        run: |
-          echo '{"registry-mirrors": ["https://github-runner-dockerhub-cache.canonical.com:5000"]}' | sudo tee /etc/docker/daemon.json
       - name: Restart dockerd
         run: sudo systemctl restart docker
       - name: Run tests with docker-compose

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -25,12 +25,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
+      - name: Create Docker config with mirror
+        run: |
+          MIRROR_URL="${DOCKERHUB_MIRROR:-https://github-runner-dockerhub-cache.canonical.com:5000}"
+          mkdir -p ~/.docker
+          echo "{\"registry-mirrors\": [\"${MIRROR_URL}\"]}" > ~/.docker/daemon.json
+          echo '[registry."docker.io"]' > $GITHUB_WORKSPACE/buildkitd.toml
+          echo "  mirrors = [\"${MIRROR_URL}\"]" >> $GITHUB_WORKSPACE/buildkitd.toml
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
         with:
-          config-inline: |
-            [registry."docker.io"]
-              mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
+          buildkitd-config: ${{ github.workspace }}/buildkitd.toml
       - name: Install docker-compose
         run: |
           COMPOSE_URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)"


### PR DESCRIPTION
Since the runners are getting moved to PS7, we need to change the setup and use the `DOCKERHUB_MIRROR` environment variable provided by a runner. The default value is specified in case a job gets picked up by a PS6 runner, which may not provide such variable

UPD: The usage of the mirror has been dropped.