### PR TITLE
Update AppArmor profile to fix execution in lxc

### DIFF
--- a/client/debian/usr.bin.hwctl
+++ b/client/debian/usr.bin.hwctl
@@ -17,6 +17,7 @@ profile hwctl /usr/bin/hwctl {
   include <abstractions/nameservice-strict>
   include <abstractions/openssl>
   include <abstractions/ssl_certs>
+  include <abstractions/consoles>
 
   network inet dgram,
   network inet6 dgram,
@@ -24,21 +25,23 @@ profile hwctl /usr/bin/hwctl {
   network inet6 stream,
   network netlink raw,
 
+  @{exec_path} mr,
+
   /sys/firmware/dmi/tables/* r,  # for collecting SMBIOS info
   /sys/devices/system/cpu/cpufreq/policy*/cpuinfo_max_freq r,
-  /sys/fs/cgroup/**/cpu.max r,
+  /sys/fs/cgroup/{,**/}cpu.max r,
 
   @{PROC}/version       r,
   @{PROC}/@{pid}/cgroup r,
 
   # for collecting OS information
-  /usr/bin/kmod cx,
-  /etc/os-release      r,
+  /usr/bin/kmod   cx,
+  /etc/os-release r,
 
   profile kmod /usr/bin/kmod {
     include <abstractions/base>
 
-    /usr/bin/kmod             r,
+    @{exec_path}              r,
     @{PROC}/{cmdline,modules} r,
     @{sys}/module/**          r,  # for fetching kernel modules
   }


### PR DESCRIPTION
Fixes #319 and [C3-1133](https://warthogs.atlassian.net/browse/C3-1133)
Updates the AppArmor profile to fix denials that occur while the binary is executed in LXC.

[C3-1133]: https://warthogs.atlassian.net/browse/C3-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ