### PR TITLE
Add docker-buildx step to the publish_server action

### DIFF
--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This PR adds the missing step in the `publish_server.yaml` action to set up docker build.

Without is the following error occurs:

```
Run docker/build-push-action@v6
GitHub Actions runtime token ACs
Docker info
Proxy configuration
Error: Docker buildx is required. See https://github.com/docker/setup-buildx-action to set up build.
```