### PR TITLE
Match system category when looking for motherboard

### DIFF
--- a/server/hwapi/data_models/repository.py
+++ b/server/hwapi/data_models/repository.py
@@ -76,7 +76,7 @@ def get_vendor_by_name(db: Session, name: str) -> models.Vendor | None:
 
 
 def get_board(db: Session, vendor_name: str, product_name: str) -> models.Device | None:
-    """Return device object (category==BOARD) matching given board data"""
+    """Return device object matching given board data"""
     stmt = (
         select(models.Device)
         .join(models.Vendor)
@@ -85,7 +85,11 @@ def get_board(db: Session, vendor_name: str, product_name: str) -> models.Device
                 models.Vendor.name.ilike(f"%{_clean_vendor_name(vendor_name)}%"),
                 models.Device.name.ilike(product_name),
                 models.Device.category.in_(
-                    [DeviceCategory.BOARD.value, DeviceCategory.OTHER.value]
+                    [
+                        DeviceCategory.BOARD.value,
+                        DeviceCategory.SYSTEM.value,
+                        DeviceCategory.OTHER.value,
+                    ]
                 ),
             )
         )

--- a/server/tests/data_generator.py
+++ b/server/tests/data_generator.py
@@ -176,6 +176,7 @@ class DataGenerator:
         name: str = "Test Board",
         version: str = "v1.0",
         reports: list[models.Report] | None = None,
+        category: DeviceCategory = DeviceCategory.BOARD,
     ) -> models.Device:
         return self.gen_device(
             vendor=vendor,
@@ -183,7 +184,7 @@ class DataGenerator:
             name=name,
             version=version,
             bus=BusType.dmi,
-            category=DeviceCategory.BOARD,
+            category=category,
             reports=reports,
         )
 


### PR DESCRIPTION
Turned out that sometimes motherboard is classified as `SYSTEM` device (for example here: https://ubuntu.com/certified/202006-27980)
The server matching logic is being updated here to handle this case.