### PR TITLE
Add workflow validation

### DIFF
--- a/.github/workflows/openapi_gh_pages.yaml
+++ b/.github/workflows/openapi_gh_pages.yaml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,24 +19,29 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
     runs-on: [self-hosted, linux, large, noble, x64]
     defaults:
       run:
         working-directory: server
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/configure-pages@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: "22.x"
       - run: mkdir -p dist
       - run: |
           npx @redocly/cli build-docs ./schemas/openapi.yaml -o ./dist/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './server/dist'
+          path: "./server/dist"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/package_client.yaml
+++ b/.github/workflows/package_client.yaml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
       - name: Build
         id: snapcraft
-        uses: canonical/snapcraft-multiarch-action@v1
+        uses: canonical/snapcraft-multiarch-action@64be34b955c6f5085a086ab4e299e9f483652dee # v1.10.0
         with:
           path: client
           architecture: ${{ matrix.arch }}
@@ -55,7 +55,7 @@ jobs:
           path: ${{ steps.snapcraft.outputs.snap }}
       - name: Publish
         if: github.ref == 'refs/heads/main'
-        uses: snapcore/action-publish@v1
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:

--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]
@@ -6,7 +8,7 @@ on:
       - ".github/workflows/publish_server.yaml"
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0' # Rebuild every Sunday at 00:00
+    - cron: "0 0 * * 0" # Rebuild every Sunday at 00:00
 
 env:
   REGISTRY: ghcr.io
@@ -23,21 +25,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push backend Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./server/
           file: ./server/Dockerfile
@@ -51,8 +55,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.7.0
+        uses: canonical/charming-actions/upload-charm@1753e0803f70445132e92acd45c905aba6473225 # 2.7.0
         with:
           charm-path: "server/charm"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -1,14 +1,16 @@
 name: Run integration tests
+permissions:
+  contents: read
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - server/**
       - client/**
       - tests/**
       - ".github/workflows/run_integration_tests.yaml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - server/**
       - client/**
@@ -25,11 +27,13 @@ jobs:
       run:
         working-directory: integration-tests
     steps:
-    - uses: actions/checkout@v4
-    - name: Install docker compose
-      run: |
-        sudo apt update
-        sudo apt install -y docker-compose-v2
-    - name: Build and run integration tests
-      run: |
-        docker compose up --build --abort-on-container-exit
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install docker compose
+        run: |
+          sudo apt update
+          sudo apt install -y docker-compose-v2
+      - name: Build and run integration tests
+        run: |
+          docker compose up --build --abort-on-container-exit

--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -1,13 +1,15 @@
 name: Test client lib and CLI tool
+permissions:
+  contents: read
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - client/**
       - Cargo.*
       - ".github/workflows/test_client.yaml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - client/**
       - Cargo.*
@@ -15,7 +17,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 
 jobs:
   lint-and-test:
@@ -25,15 +26,17 @@ jobs:
         working-directory: client
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y pkgconf libssl-dev build-essential
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup override set stable
       - run: cargo install cargo-vendor-filterer
       - name: Vendor the dependencies
         run: |
@@ -65,15 +68,17 @@ jobs:
     needs: lint-and-test
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y pkgconf libssl-dev build-essential
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup override set stable
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -33,10 +33,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkgconf libssl-dev build-essential
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup override set stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
       - run: cargo install cargo-vendor-filterer
       - name: Vendor the dependencies
         run: |
@@ -50,12 +50,8 @@ jobs:
           cat ~/.cargo/config.toml
       - run: cargo build --offline
       - run: cargo check
-      - run: |
-          rustup component add rustfmt
-          cargo fmt --all -- --check
-      - run: |
-          rustup component add clippy
-          cargo clippy --all-features --verbose
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-features --verbose
       - run: cargo clippy --tests --verbose
       - name: Run cargo test
         run: cargo test
@@ -75,15 +71,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkgconf libssl-dev build-essential
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup override set stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+        with:
+          toolchain: stable
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Install tox
-        run: |
-          pip install tox
+        run: pip install tox
       - name: Run tox
         run: tox

--- a/.github/workflows/test_hwlib_debian_build.yaml
+++ b/.github/workflows/test_hwlib_debian_build.yaml
@@ -1,13 +1,15 @@
 name: Test build hwlib Rust package with sbuild
+permissions:
+  contents: read
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - client/**
       - Cargo.*
       - ".github/workflows/test_hwlib_debian_build.yaml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - client/**
       - Cargo.*
@@ -15,7 +17,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 
 jobs:
   validate-version:
@@ -27,11 +28,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup override set stable
       - name: Get version from git tag
         id: get-version
         run: |
@@ -46,22 +48,26 @@ jobs:
           echo "Git tag base version: $BASE_VERSION"
       - name: Check hwlib and hwctl Cargo versions
         run: |
-          echo "Using Git tag version: ${{ steps.get-version.outputs.version }}"
+          echo "Using Git tag version: $GIT_TAG_VERSION"
           for manifest in hwlib/Cargo.toml hwctl/Cargo.toml; do
             CARGO_VERSION=$(cargo metadata --manifest-path "$manifest" --no-deps --format-version 1 | jq -r '.packages[0].version')
-            if [[ $CARGO_VERSION != ${{ steps.get-version.outputs.version }} ]]; then
-              echo "Version mismatch in $manifest: $CARGO_VERSION (expected ${{ steps.get-version.outputs.version }})"
+            if [[ $CARGO_VERSION != $GIT_TAG_VERSION ]]; then
+              echo "Version mismatch in $manifest: $CARGO_VERSION (expected $GIT_TAG_VERSION)"
               exit 1
             fi
           done
+        env:
+          GIT_TAG_VERSION: ${{ steps.get-version.outputs.version }}
       - name: Check Debian changelog version
         run: |
-          echo "Using Git tag version: ${{ steps.get-version.outputs.version }}"
+          echo "Using Git tag version: $GIT_TAG_VERSION"
           DEBIAN_VERSION=$(dpkg-parsechangelog --show-field Version | cut -d'~' -f1)
-          if [[ $DEBIAN_VERSION != ${{ steps.get-version.outputs.version }} ]]; then
-            echo "Debian changelog version mismatch: $DEBIAN_VERSION (expected ${{ steps.get-version.outputs.version }})"
+          if [[ $DEBIAN_VERSION != $GIT_TAG_VERSION ]]; then
+            echo "Debian changelog version mismatch: $DEBIAN_VERSION (expected $GIT_TAG_VERSION)"
             exit 1
           fi
+        env:
+          GIT_TAG_VERSION: ${{ steps.get-version.outputs.version }}
 
   build:
     runs-on: [self-hosted, linux, large, noble, x64]
@@ -70,63 +76,67 @@ jobs:
         working-directory: client
     needs: [validate-version]
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v4
-    # Prevent lxd-agent from getting restarted on apt upgrades.
-    # https://warthogs.atlassian.net/browse/ISD-2139
-    - name: Disable lxd-agent restart
-      run: |
-        mkdir -p /etc/needrestart/conf.d
-        echo '$nrconf{override_rc}{qr(^lxd-agent.service$)} = 0;' | sudo tee /etc/needrestart/conf.d/lxdagent.conf
-    - name: Download dependencies
-      run: |
-        set -xeu
-        sudo DEBIAN_FRONTEND=noninteractive apt -y update
-        sudo DEBIAN_FRONTEND=noninteractive apt install -y \
-          sbuild \
-          schroot \
-          debootstrap \
-          ubuntu-dev-tools \
-          distro-info-data \
-          dh-cargo \
-          dh-apparmor \
-          pkg-config \
-          libssl-dev
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Vendor the dependencies
-      run: |
-        cargo install cargo-vendor-filterer
-        ./debian/vendor-rust.sh
-    - name: Generate checksums
-      run: ./debian/generate_checksums.py
-    - run: dpkg-buildpackage -us -uc -S
-    - name: Setup sbuild and build the package
-      run: |
-        set -xeu
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      # Prevent lxd-agent from getting restarted on apt upgrades.
+      # https://warthogs.atlassian.net/browse/ISD-2139
+      - name: Disable lxd-agent restart
+        run: |
+          mkdir -p /etc/needrestart/conf.d
+          echo '$nrconf{override_rc}{qr(^lxd-agent.service$)} = 0;' | sudo tee /etc/needrestart/conf.d/lxdagent.conf
+      - name: Download dependencies
+        run: |
+          set -xeu
+          sudo DEBIAN_FRONTEND=noninteractive apt -y update
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y \
+            sbuild \
+            schroot \
+            debootstrap \
+            ubuntu-dev-tools \
+            distro-info-data \
+            dh-cargo \
+            dh-apparmor \
+            pkg-config \
+            libssl-dev
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup override set stable
+      - name: Vendor the dependencies
+        run: |
+          cargo install cargo-vendor-filterer
+          ./debian/vendor-rust.sh
+      - name: Generate checksums
+        run: ./debian/generate_checksums.py
+      - run: dpkg-buildpackage -us -uc -S
+      - name: Setup sbuild and build the package
+        run: |
+          set -xeu
 
-        sudo sbuild-adduser $USER
-        cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
+          sudo sbuild-adduser $USER
+          cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
 
-        sg sbuild -c "mk-sbuild questing"
+          sg sbuild -c "mk-sbuild questing"
 
-        PACKAGE_DSC=$(find ../ -name "*.dsc" | head -n 1)
-        if [ -z "$PACKAGE_DSC" ]; then
-          echo "No .dsc file found"
-          exit 1
-        fi
-        echo "Running sbuild for $PACKAGE_DSC"
-        sg sbuild -c "sbuild $PACKAGE_DSC -d questing -v --resolve-alternatives --no-clean-source --no-run-lintian"
+          PACKAGE_DSC=$(find ../ -name "*.dsc" | head -n 1)
+          if [ -z "$PACKAGE_DSC" ]; then
+            echo "No .dsc file found"
+            exit 1
+          fi
+          echo "Running sbuild for $PACKAGE_DSC"
+          sg sbuild -c "sbuild $PACKAGE_DSC -d questing -v --resolve-alternatives --no-clean-source --no-run-lintian"
 
-        mv *.deb '${{ runner.temp }}'
-    # TODO: Uncomment this step one lintian gets updated
-    # - run: lintian --pedantic --verbose
-    - name: Archive artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ci-debs-questing
-        path: '${{ runner.temp }}/*.deb'
-        retention-days: 3
+          mv *.deb "$RUNNER_TEMP"
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+      # TODO: Uncomment this step one lintian gets updated
+      # - run: lintian --pedantic --verbose
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-debs-questing
+          path: "${{ runner.temp }}/*.deb"
+          retention-days: 3

--- a/.github/workflows/test_hwlib_debian_build.yaml
+++ b/.github/workflows/test_hwlib_debian_build.yaml
@@ -30,10 +30,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup override set stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+        with:
+          toolchain: stable
       - name: Get version from git tag
         id: get-version
         run: |
@@ -101,10 +100,9 @@ jobs:
             pkg-config \
             libssl-dev
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup override set stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+        with:
+          toolchain: stable
       - name: Vendor the dependencies
         run: |
           cargo install cargo-vendor-filterer

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -77,12 +77,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Install poetry
+        run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - uses: Gr1N/setup-poetry@12c727a3dcf8c1a548d8d041c9d5ef5cebb3ba2e
-        with:
-          poetry-version: "2.0.0"
+          cache: poetry
       - run: poetry install
       - name: Start FastAPI application
         run: poetry run uvicorn hwapi.main:app --port 8001 &

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -1,12 +1,14 @@
 name: Test API server
+permissions:
+  contents: read
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - server/**
       - ".github/workflows/test_server.yaml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - server/**
       - ".github/workflows/test_server.yaml"
@@ -24,7 +26,8 @@ jobs:
       - name: Checkout repo & submodules
         uses: actions/checkout@v4
         with:
-          submodules: "true"
+          persist-credentials: false
+          submodules: true
       - name: Install docker-compose
         run: |
           COMPOSE_URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)"
@@ -57,13 +60,13 @@ jobs:
         with:
           name: test_coverage
       - name: Report Coverage and annotate PR (if exists)
-        uses: orgoro/coverage@v3
+        uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
         with:
-            coverageFile: coverage.xml
-            token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdAll: 0.70
-            thresholdNew: 0.80
-            thresholdModified: 0.0
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          thresholdAll: 0.70
+          thresholdNew: 0.80
+          thresholdModified: 0.0
 
   compare-openapi:
     runs-on: [self-hosted, linux, large, noble, x64]
@@ -72,6 +75,8 @@ jobs:
         working-directory: server
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -78,7 +78,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install poetry
-        run: pipx install poetry
+        run: pip install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -77,12 +77,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Install poetry
-        run: pip install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-          cache: poetry
+      - name: Install poetry
+        run: pip install poetry
       - run: poetry install
       - name: Start FastAPI application
         run: poetry run uvicorn hwapi.main:app --port 8001 &

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -54,6 +54,9 @@ jobs:
     runs-on: [self-hosted, linux, large, noble, x64]
     if: github.event_name == 'pull_request'
     needs: [test]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Download build tests coverage report
         uses: actions/download-artifact@v4

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -1,0 +1,30 @@
+name: Validate Workflows
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/actions/**
+      - .github/workflows/**
+  push:
+    branches: [main]
+    paths:
+      - .github/actions/**
+      - .github/workflows/**
+
+jobs:
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      - name: Run zizmor
+        run: uvx zizmor --pedantic .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds [`zizmor`](https://docs.zizmor.sh/) validation to the workflows for security checks.

The following changes are most relevant:

- Pinning non-`actions/*` actions to a commit SHA with version comment
- Replacing `actions-rs/toolchain` actions with `dtolnay/rust-toolchain` (`actions-rs` is [unmaintained/deprecated](https://github.com/actions-rs/toolchain/issues/216))