### PR TITLE
feat(server): Add charm update libs workflow

### DIFF
--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -1,0 +1,25 @@
+name: Auto-update Charm Libraries
+permissions: {}
+on:
+  workflow_dispatch:
+  schedule:
+    # Checks regularly the upstream every 4 hours
+    - cron: "0 */4 * * *"
+
+jobs:
+  update-libs:
+    name: Check Libraries
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@636230eacd68c9cb99a2e926126e2bf71a2f87c0 # v1
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
+      OBSERVABILITY_NOCTUA_TOKEN: ${{ secrets.OBSERVABILITY_TOKEN }}
+      NOCTUA_GPG_PRIVATE: ${{ secrets.OBSERVABILITY_GPG_PRIVATE }}
+      NOCTUA_GPG_PASSPHRASE: ${{ secrets.OBSERVABILITY_GPG_PASSPHRASE }}
+    with:
+      charm-path: server/charm
+      commit-username: Canonical-Certification-Bot
+      commit-email: solutions-qa@lists.canonical.com


### PR DESCRIPTION
Depends on #353.

This PR adds a workflow to auto-update the server charm libraries that the charm depends on.

The following secrets should be added to the repository:

- `OBSERVABILITY_TOKEN`: A token that is able to read content, write PRs, and write issues. This should be a token from the Certification bot.
- `OBSERVABILITY_GPG_PRIVATE`: The private GPG key for Certification bot.
- `OBSERVABILITY_GPG_PASSPHRASE`: The private GPG key's passphrase.

See: https://github.com/canonical/observability/blob/v1/.github/workflows/charm-update-libs.yaml