### PR TITLE
feat(hwlib): Raise an error when the server returns an error

### DIFF
--- a/client/hwlib/src/lib.rs
+++ b/client/hwlib/src/lib.rs
@@ -44,6 +44,7 @@ pub async fn send_certification_status_request(
     let mut server_url = url.clone();
     server_url.push_str(CERT_STATUS_ENDPOINT);
     let response = client.post(server_url).json(request).send().await?;
+    response.error_for_status_ref()?;
     let response_text = response.text().await?;
     let typed_response: CertificationStatusResponse = serde_json::from_str(&response_text)?;
 


### PR DESCRIPTION
This PR adds a line to raise an error if the response type is not okay (in the 200 range).

This should make some errors (e.g., #361) more readable.

For example, if I run it right now, I see:

```console
$ sudo ./target/debug/hwctl 
[sudo] password for pavalos: 
ERROR: cannot send certification status request

Caused by:
    HTTP status server error (503 Service Unavailable) for url (https://hw.ubuntu.com/v1/certification/status)
```

Instead of:

```console
$ sudo ./target/debug/hwctl 
ERROR: cannot send certification status request

Caused by:
    expected value at line 1 column 1
```