### PR TITLE
Add CI to publish hwlib when a tag gets created

### DIFF
--- a/.github/workflows/publish_client_crates.yaml
+++ b/.github/workflows/publish_client_crates.yaml
@@ -1,0 +1,45 @@
+name: Publish hwlib to crates.io
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: [self-hosted, linux, large, noble, x64]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+          persist-credentials: false
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+      with:
+        toolchain: stable
+    - name: Extract version from tag
+      id: get_version
+      run: |
+        TAG=${GITHUB_REF#refs/tags/v}
+        echo "version=$TAG" >> $GITHUB_OUTPUT
+        echo "Tag version: $TAG"
+    - name: Verify version matches Cargo.toml
+      working-directory: client
+      env:
+        TAG_VERSION: ${{ steps.get_version.outputs.version }}
+      run: |
+        CARGO_VERSION=$(grep '^version =' Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')
+        echo "Cargo.toml version: $CARGO_VERSION"
+        echo "Tag version: $TAG_VERSION"
+        if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+          echo "Error: Version mismatch between tag ($TAG_VERSION) and Cargo.toml ($CARGO_VERSION)"
+          exit 1
+        fi
+    - name: Publish hwlib to crates.io
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      working-directory: client
+      run: cargo publish -p hwlib --locked --verbose


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically publish the hwlib crate to crates.io when a new `v*.*.*` tag is pushed.

* Runs only on version tags (e.g. `v0.9.1`)
* Verifies tag matches client/Cargo.toml version
* Publishes hwlib using cargo publish with lockfile enforcement

`hwctl` cannot be published now due to the following error:
```
$ cargo publish -p hwctl
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `hwlib` does not specify a version
Note: The published dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```
Since the CLI tool can be installed as deb or snap and the client consumers will need the library as a crate, we can just publish the lib

Crates.io API token must be set as `CARGO_REGISTRY_TOKEN` in repository secrets.