### PR TITLE
Allow build-and-push-charm step to create releases

### DIFF
--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -53,6 +53,9 @@ jobs:
   build-and-push-charm:
     runs-on: [self-hosted, linux, xlarge, jammy, x64]
     needs: build-and-push-image
+    permissions:
+      contents: write
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The PR adds the lacking permissions so the job can create tags and releases