### PR TITLE
fix: complete changelog entries

### DIFF
--- a/client/debian/changelog
+++ b/client/debian/changelog
@@ -4,8 +4,11 @@ rust-hwlib (0.9.2) questing; urgency=medium
   * Use minreq crate instead of reqwest and adjust the code
   * Remove the debian/vendor-rust.sh script
   * Remove examples and tests from rust-vendor/ directory
-  * Remove debian/compat file and use debhelper-compat in package's
-    Build-Depends instead
+  * Remove debian/compat file and use debhelper-compat in Build-Depends instead
+  * Fix AppArmor profile:
+    - Remove exec_path usage
+    - Add kmod denied rm mask
+  * Update readme and contributing files
 
  -- Nadzeya Hutsko <nadzeya.hutsko@canonical.com>  Mon, 07 Jul 2025 15:32:12 +0200
 


### PR DESCRIPTION
Make sure changelog matches what we've changed since v0.9.1