### PR TITLE
fix: update apparmor rm mask

### DIFF
--- a/client/debian/changelog
+++ b/client/debian/changelog
@@ -5,7 +5,7 @@ rust-hwlib (0.9.2) questing; urgency=medium
   * Remove the debian/vendor-rust.sh script
   * Remove examples and tests from rust-vendor/ directory
   * Remove debian/compat file and use debhelper-compat in Build-Depends instead
-  * Fix apparmor kmod denied rm mask
+  * Fix apparmor kmod denied mr mask
   * Update readme and contributing files
 
  -- Nadzeya Hutsko <nadzeya.hutsko@canonical.com>  Mon, 07 Jul 2025 15:32:12 +0200

--- a/client/debian/usr.bin.hwctl
+++ b/client/debian/usr.bin.hwctl
@@ -41,7 +41,7 @@ profile hwctl /usr/bin/hwctl {
   profile kmod /usr/bin/kmod {
     include <abstractions/base>
 
-    /usr/bin/kmod             rm,
+    /usr/bin/kmod             mr,
     @{PROC}/{cmdline,modules} r,
     @{sys}/module/**          r,  # for fetching kernel modules
   }


### PR DESCRIPTION
While the behaviour and the meaning of the masks remain the same, it just becomes less confusing and doesn't look like `rm` (removal)
The same syntax is used for the profile bin: `/usr/bin/hwctl mr,`