### PR TITLE
fix(ci): install dependencies in publish_client_crates.yaml

### DIFF
--- a/.github/workflows/publish_client_crates.yaml
+++ b/.github/workflows/publish_client_crates.yaml
@@ -16,7 +16,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-          persist-credentials: false
+        persist-credentials: false
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkgconf libssl-dev build-essential
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
       with:


### PR DESCRIPTION
Fixes the CI to publish the crate to crates.io when a tag gets created
https://github.com/canonical/hardware-api/actions/runs/16264089451/job/45915750398