### PR TITLE
ci: Improve server testability

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -25,25 +25,20 @@ jobs:
       run:
         working-directory: server
     steps:
-      - name: Checkout repo & submodules
+      - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          submodules: true
-      - name: Install docker-compose
-        run: |
-          COMPOSE_URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)"
-          echo "Downloading docker-compose from $COMPOSE_URL"
-          sudo curl -L  -L $COMPOSE_URL -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          echo `docker-compose --version`
-      - name: Restart dockerd
-        run: sudo systemctl restart docker
-      - name: Run tests with docker-compose
-        run: |
-          docker-compose up --attach-dependencies --abort-on-container-exit hwapi-test
-          sudo chown $USER -R coverage
-          sudo chgrp $USER -R coverage
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: sudo apt-get install -yqq python3-poetry tox
+      - name: Lint
+        run: tox run -e lint
+      - name: Unit
+        run: tox run -e unit
       - name: Upload coverage.xml as an artifact
         uses: actions/upload-artifact@v5
         with:

--- a/server/CONTRIBUTING.md
+++ b/server/CONTRIBUTING.md
@@ -6,6 +6,27 @@ Server.
 For general contribution guidelines for the `hardware-api` project,
 refer to the [contribution guide](../CONTRIBUTING.md).
 
+## Development Environment
+
+You can create an environment for development with [`poetry`][poetry]:
+
+```shell
+poetry install
+```
+
+## Testing
+
+This project uses [`tox`][tox] for managing test environments. There are some
+pre-configured environments that can be used for linting and formatting code
+when you're preparing contributions to the project:
+
+```shell
+tox run -e format  # update your code according to linting rules
+tox run -e lint    # code style
+tox run -e unit    # unit (coverage) tests
+tox                # runs 'format', 'lint', and 'unit'
+```
+
 ## Deploy the Server
 
 ### Deploy with Docker
@@ -57,15 +78,6 @@ specifying the `C3_URL` environment variable:
 ```bash
 export C3_URL=http://your.c3.instance  # e.g., https://certification.canonical.com
 docker compose up --attach-dependencies --build hwapi-dev
-```
-
-#### Run Tests with `docker-compose`
-
-To run tests inside a Docker container (again, using `--build` when iterating
-on source code changes, to force the image to be rebuilt):
-
-```shell
-docker compose up --attach-dependencies --force-recreate --abort-on-container-exit --build hwapi-test
 ```
 
 ## Access the API Schema

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -15,28 +15,6 @@ services:
     ports:
       - "8080:8080"
 
-  hwapi-test:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        IMPORT_TOOL_PATH: ""
-        C3_URL: https://c3_url
-        DB_URL: sqlite:////home/server/test.db
-    command: >
-      bash -c '
-        ruff format --check hwapi/ scripts/ tests/ &&
-        ruff check hwapi/ scripts/ tests/ --no-cache &&
-        mypy hwapi/ scripts/ tests/ &&
-        coverage run --source "hwapi/" -m pytest tests/ -vv &&
-        cd .. && cp server/.coverage . &&
-        coverage xml -o server/coverage/coverage.xml'
-    working_dir: /home/server
-    volumes:
-      - ./coverage:/home/server/coverage
-    ports:
-      - "8080:8080"
-
   hwapi:
     build:
       context: .

--- a/server/hwapi/data_models/data_validators/__init__.py
+++ b/server/hwapi/data_models/data_validators/__init__.py
@@ -25,16 +25,14 @@ from hwapi.data_models.data_validators.devices import (
     NetworkAdapterValidator,
     PCIPeripheralValidator,
     ProcessorValidator,
+    USBPeripheralValidator,
     VideoCaptureValidator,
     WirelessAdapterValidator,
-    USBPeripheralValidator,
 )
-
 from hwapi.data_models.data_validators.software import (
     KernelPackageValidator,
     OSValidator,
 )
-
 
 __all__ = [
     "AudioValidator",

--- a/server/hwapi/data_models/models.py
+++ b/server/hwapi/data_models/models.py
@@ -19,16 +19,15 @@
 from datetime import date, datetime
 
 from sqlalchemy import (
-    ForeignKey,
-    String,
-    UniqueConstraint,
-    Table,
     Column,
-    Integer,
     Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    UniqueConstraint,
 )
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from .enums import BusType, DeviceCategory
 

--- a/server/hwapi/data_models/repository.py
+++ b/server/hwapi/data_models/repository.py
@@ -17,7 +17,8 @@
 """Functions for working with the DB using SQLAlchemy ORM"""
 
 from typing import Any, Sequence
-from sqlalchemy import select, and_, null
+
+from sqlalchemy import and_, null, select
 from sqlalchemy.orm import Session, selectinload
 
 from hwapi.data_models import models

--- a/server/hwapi/endpoints/certification/certification.py
+++ b/server/hwapi/endpoints/certification/certification.py
@@ -17,6 +17,7 @@
 """The endpoints for working with certification status"""
 
 import logging
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
@@ -45,7 +46,7 @@ router = APIRouter()
     ),
 )
 def check_certification(
-    system_info: CertificationStatusRequest, db: Session = Depends(get_db)
+    system_info: CertificationStatusRequest, db: Annotated[Session, Depends(get_db)]
 ) -> (
     CertifiedResponse
     | NotCertifiedResponse

--- a/server/hwapi/endpoints/certification/certification.py
+++ b/server/hwapi/endpoints/certification/certification.py
@@ -17,6 +17,7 @@
 """The endpoints for working with certification status"""
 
 import logging
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -25,10 +26,10 @@ from hwapi.data_models.setup import get_db
 from hwapi.endpoints.certification import logic, response_builders
 from hwapi.endpoints.certification.request_validators import CertificationStatusRequest
 from hwapi.endpoints.certification.response_validators import (
+    CertifiedImageExistsResponse,
     CertifiedResponse,
     NotCertifiedResponse,
     RelatedCertifiedSystemExistsResponse,
-    CertifiedImageExistsResponse,
 )
 
 router = APIRouter()

--- a/server/hwapi/endpoints/certification/logic.py
+++ b/server/hwapi/endpoints/certification/logic.py
@@ -18,10 +18,10 @@
 
 from sqlalchemy.orm import Session
 
-from hwapi.data_models import repository, models
+from hwapi.data_models import models, repository
 from hwapi.data_models.data_validators import (
-    BoardValidator,
     BiosValidator,
+    BoardValidator,
     ProcessorValidator,
 )
 

--- a/server/hwapi/endpoints/certification/response_builders.py
+++ b/server/hwapi/endpoints/certification/response_builders.py
@@ -17,12 +17,12 @@
 
 from sqlalchemy.orm import Session
 
+from hwapi.data_models import data_validators, models, repository
 from hwapi.endpoints.certification.response_validators import (
+    CertifiedImageExistsResponse,
     CertifiedResponse,
     RelatedCertifiedSystemExistsResponse,
-    CertifiedImageExistsResponse,
 )
-from hwapi.data_models import repository, data_validators, models
 
 
 def build_related_certified_response(

--- a/server/hwapi/endpoints/certification/response_validators.py
+++ b/server/hwapi/endpoints/certification/response_validators.py
@@ -17,9 +17,9 @@
 """Validator models for request/response bodies"""
 
 from typing import Literal
+
 from pydantic import BaseModel
 
-from hwapi.data_models.enums import CertificationStatus
 from hwapi.data_models.data_validators import (
     AudioValidator,
     BiosValidator,
@@ -33,6 +33,7 @@ from hwapi.data_models.data_validators import (
     VideoCaptureValidator,
     WirelessAdapterValidator,
 )
+from hwapi.data_models.enums import CertificationStatus
 
 
 class CertifiedResponse(BaseModel):

--- a/server/hwapi/external/c3/client.py
+++ b/server/hwapi/external/c3/client.py
@@ -369,13 +369,13 @@ class C3Client:
             created,
         )
 
+        # If there is already device.codename filled, don't overwrite it with Unknown value
         if (
             device.category == enums.DeviceCategory.PROCESSOR
             and device_instance.cpu_codename
+            and not (device_instance.cpu_codename == "Unknown" and device.codename)
         ):
-            # If there is already device.codename filled, don't overwrite it with Unknown value
-            if not (device_instance.cpu_codename == "Unknown" and device.codename):
-                device.codename = device_instance.cpu_codename
+            device.codename = device_instance.cpu_codename
 
         report, created = get_or_create(
             self.db,

--- a/server/hwapi/external/c3/client.py
+++ b/server/hwapi/external/c3/client.py
@@ -16,29 +16,28 @@
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 """The module for working with C3 API"""
 
-import requests
 import logging
 import time
 from http import HTTPStatus
+from sqlite3 import IntegrityError as SQLite3IntegrityError
 from typing import Callable, Type
+
+import requests
 from pydantic import BaseModel
 from requests.adapters import HTTPAdapter
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 from urllib3.util.retry import Retry
 
-from sqlite3 import IntegrityError as SQLite3IntegrityError
-from sqlalchemy.orm import Session
-from sqlalchemy.exc import IntegrityError
-
-from hwapi.data_models import models, enums
+from hwapi.data_models import enums, models
 from hwapi.data_models.repository import (
+    get_certificate_by_name,
+    get_machine_by_canonical_id,
     get_or_create,
     get_vendor_by_name,
-    get_machine_by_canonical_id,
-    get_certificate_by_name,
 )
 from hwapi.external.c3 import response_models, urls
 from hwapi.external.c3.helpers import progress_bar
-
 
 logger = logging.getLogger(__name__)
 

--- a/server/hwapi/external/c3/response_models.py
+++ b/server/hwapi/external/c3/response_models.py
@@ -15,7 +15,8 @@
 # Written by:
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 
-from datetime import datetime, date
+from datetime import date, datetime
+
 from pydantic import BaseModel
 
 from hwapi.data_models.enums import BusType, DeviceCategory

--- a/server/hwapi/external/c3/urls.py
+++ b/server/hwapi/external/c3/urls.py
@@ -18,7 +18,6 @@
 
 import os
 
-
 C3_URL = os.environ.get("C3_URL", "https://certification.canonical.com")
 PUBLIC_CERTIFICATES_URL = f"{C3_URL}/api/v2/public-certificates/"
 PUBLIC_DEVICES_URL = f"{C3_URL}/api/v2/public-devices/"

--- a/server/hwapi/main.py
+++ b/server/hwapi/main.py
@@ -22,7 +22,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from hwapi.router import router
 
-
 logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 app = FastAPI(redirect_slashes=False)

--- a/server/hwapi/router.py
+++ b/server/hwapi/router.py
@@ -19,8 +19,8 @@
 import yaml
 from fastapi import APIRouter, Response
 from fastapi.openapi.utils import get_openapi
-from .endpoints.certification import certification
 
+from .endpoints.certification import certification
 
 router = APIRouter()
 router.include_router(

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -30,6 +30,19 @@ sqlalchemy-utils = "^0.41.2"
 requests-mock = "^1.12.1"
 pytest-cov = "^6.0.0"
 
+[tool.ruff]
+lint.extend-select = [
+    "FAST", # fastapi
+    "A",    # flake8-builtins
+    "S",    # flake8-bandit (security)
+    "SIM",  # flake8-simplify
+    "B",    # flake8-bugbear
+    "I",    # isort
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**.py" = ["S101"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/server/scripts/import_from_c3.py
+++ b/server/scripts/import_from_c3.py
@@ -18,13 +18,12 @@
 """Import data from C3"""
 
 import logging
-from requests.exceptions import HTTPError
 
+from requests.exceptions import HTTPError
 from sqlalchemy.orm import Session
 
 from hwapi.data_models.setup import engine
 from hwapi.external.c3.client import C3Client
-
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/server/scripts/import_test_data.py
+++ b/server/scripts/import_test_data.py
@@ -17,12 +17,13 @@
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 """Script for importing test machine data using mocked C3 responses"""
 
-import os
 import json
 import logging
+import os
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Any, Dict
-from importlib.util import spec_from_file_location, module_from_spec
+
 from requests_mock import Mocker
 
 logging.basicConfig(
@@ -123,7 +124,7 @@ def main() -> None:
 
     except Exception as e:
         logger.error("Import failed: %s", str(e))
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
 
 if __name__ == "__main__":

--- a/server/scripts/seed_db.py
+++ b/server/scripts/seed_db.py
@@ -17,14 +17,13 @@
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 """Populate SQLite DB with dummy data"""
 
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta
 
 from sqlalchemy.orm import Session
 
 from hwapi.data_models import models
 from hwapi.data_models.setup import engine
-
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -17,8 +17,8 @@
 #        Omar Selo <omar.selo@canonical.com
 
 from os import environ
-import pytest
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -27,8 +27,8 @@ from sqlalchemy_utils import (  # type: ignore
     drop_database,
 )
 
-from hwapi.data_models.setup import get_db
 from hwapi.data_models.models import Base
+from hwapi.data_models.setup import get_db
 from hwapi.main import app
 from tests.data_generator import DataGenerator
 

--- a/server/tests/data_generator.py
+++ b/server/tests/data_generator.py
@@ -22,6 +22,9 @@ from sqlalchemy.orm import Session
 from hwapi.data_models import models
 from hwapi.data_models.enums import BusType, DeviceCategory
 
+NOW = datetime.now()
+NOW_DATE = NOW.date()
+
 
 class DataGenerator:
     def __init__(self, db_session: Session):
@@ -61,8 +64,8 @@ class DataGenerator:
         self,
         codename: str = "noble",
         release: str = "24.04",
-        release_date: date = datetime.now().date() - timedelta(days=365),
-        supported_until: date = datetime.now().date() + timedelta(days=3650),
+        release_date: date = NOW_DATE - timedelta(days=365),
+        supported_until: date = NOW_DATE + timedelta(days=3650),
     ) -> models.Release:
         created_release = models.Release(
             codename=codename,
@@ -79,11 +82,11 @@ class DataGenerator:
     ) -> models.Certificate:
         certificate = models.Certificate(
             machine=machine,
-            created_at=datetime.now(),
+            created_at=NOW,
             release=release,
             name=name
             or f"Certificate for {machine.canonical_id} with {release.codename}",
-            completed=datetime.now() + timedelta(days=10),
+            completed=NOW + timedelta(days=10),
         )
         self.db_session.add(certificate)
         self.db_session.commit()
@@ -103,7 +106,7 @@ class DataGenerator:
     def gen_bios(
         self,
         vendor: models.Vendor,
-        release_date: date = datetime.now() - timedelta(days=365),
+        release_date: date = NOW - timedelta(days=365),
         revision: str = "A01",
         version: str = "1.0.2",
     ) -> models.Bios:

--- a/server/tests/data_generator.py
+++ b/server/tests/data_generator.py
@@ -15,8 +15,10 @@
 # Written by:
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 
-from datetime import datetime, timedelta, date
+from datetime import date, datetime, timedelta
+
 from sqlalchemy.orm import Session
+
 from hwapi.data_models import models
 from hwapi.data_models.enums import BusType, DeviceCategory
 

--- a/server/tests/endpoints/certification/test_certification.py
+++ b/server/tests/endpoints/certification/test_certification.py
@@ -15,10 +15,11 @@
 # Written by:
 #        Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
 
-from pytest import LogCaptureFixture
 from fastapi.testclient import TestClient
+from pytest import LogCaptureFixture
+
 from hwapi.data_models.enums import DeviceCategory
-from tests.data_generator import DataGenerator, CertificationStatusTestHelper
+from tests.data_generator import CertificationStatusTestHelper, DataGenerator
 
 
 def test_vendor_not_found(generator: DataGenerator, test_client: TestClient):

--- a/server/tests/external/c3/test_client.py
+++ b/server/tests/external/c3/test_client.py
@@ -641,19 +641,21 @@ def test_exponential_backoff_timing(db_session: Session):
     """Test that exponential backoff delays increase correctly."""
     c3_client = C3Client(db=db_session)
 
-    with patch("time.sleep") as mock_sleep:
-        with patch.object(c3_client.session, "get") as mock_get:
-            # Configure mock to always raise timeout
-            mock_get.side_effect = requests.exceptions.ReadTimeout("Timeout")
+    with (
+        patch("time.sleep") as mock_sleep,
+        patch.object(c3_client.session, "get") as mock_get,
+    ):
+        # Configure mock to always raise timeout
+        mock_get.side_effect = requests.exceptions.ReadTimeout("Timeout")
 
-            with pytest.raises(requests.exceptions.ReadTimeout):
-                c3_client._make_request_with_retries("https://test.com")
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            c3_client._make_request_with_retries("https://test.com")
 
-            # Check that sleep was called with increasing delays: 2, 4, 8, 16
-            # (4 retries for 5 total attempts)
-            expected_delays = [2, 4, 8, 16]
-            actual_delays = [call[0][0] for call in mock_sleep.call_args_list]
-            assert actual_delays == expected_delays
+        # Check that sleep was called with increasing delays: 2, 4, 8, 16
+        # (4 retries for 5 total attempts)
+        expected_delays = [2, 4, 8, 16]
+        actual_delays = [call[0][0] for call in mock_sleep.call_args_list]
+        assert actual_delays == expected_delays
 
 
 def test_retry_with_pagination(

--- a/server/tests/external/c3/test_client.py
+++ b/server/tests/external/c3/test_client.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
-from requests.exceptions import ReadTimeout, ConnectTimeout, ConnectionError, HTTPError
+from requests.exceptions import ConnectionError, ConnectTimeout, HTTPError, ReadTimeout
 from requests_mock import Mocker
 from sqlalchemy.orm import Session
 

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,0 +1,32 @@
+[tox]
+no_package = true
+env_list = format, lint, unit
+
+[vars]
+src_path = {tox_root}/hwapi
+tests_path = {tox_root}/tests
+scripts_path = {tox_root}/scripts
+all_path = {[vars]src_path} {[vars]scripts_path} {[vars]tests_path}
+
+[testenv]
+allowlist_externals = poetry
+commands_pre =
+    poetry install --no-root --sync
+
+[testenv:format]
+description = Apply coding style standards to code
+commands =
+    poetry run ruff format {[vars]all_path}
+    poetry run ruff check --fix {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+commands =
+    poetry run ruff check {[vars]all_path}
+    poetry run ruff format --check --diff {[vars]all_path}
+    poetry run mypy {[vars]all_path}
+
+[testenv:unit]
+description = Run unit tests
+commands =
+    poetry run pytest --cov={[vars]src_path} --cov-report=term --cov-report=xml:coverage/coverage.xml --doctest-modules {[vars]tests_path}


### PR DESCRIPTION
This PR is an overhaul of the way we test the server. The following changes are noteworthy:

- Add Ruff rules (we weren't really enforcing any rules apart from the very bare minimum that Ruff includes by default)
  - Added isort, pylint, flake8 (builtins, bugbear, and bandit); these are what are used in TICS (which will be added in a follow-up PR) and we should be checking against them
  - Resolved any issues that Ruff brought up as a result of these changes
- Add `tox.ini` configuration to format, lint, and run unit/coverage tests
- Replace the Docker setup for testing with the tox setup