### PR TITLE
feat: Add public ubuntu.com/certified URL

### DIFF
--- a/client/src/models/response_validators.rs
+++ b/client/src/models/response_validators.rs
@@ -30,6 +30,7 @@ use crate::models::{
 #[serde(tag = "status")]
 pub enum CertificationStatusResponse {
     Certified {
+        certified_url: String,
         architecture: String,
         available_releases: Vec<OS>,
         bios: Bios,
@@ -40,6 +41,7 @@ pub enum CertificationStatusResponse {
     NotSeen,
     #[serde(rename = "Certified Image Exists")]
     CertifiedImageExists {
+        certified_url: String,
         architecture: String,
         bios: Bios,
         board: Board,
@@ -48,6 +50,7 @@ pub enum CertificationStatusResponse {
     },
     #[serde(rename = "Related Certified System Exists")]
     RelatedCertifiedSystemExists {
+        certified_url: String,
         architecture: String,
         board: Board,
         bios: Bios,

--- a/client/test_data/amd64/dell_xps13/response.json
+++ b/client/test_data/amd64/dell_xps13/response.json
@@ -1,5 +1,6 @@
 {
   "status": "Certified",
+  "certified_url": "https://ubuntu.com/certified/202405-34051",
   "architecture": "amd64",
   "bios": {
     "vendor": "Dell",

--- a/client/test_data/amd64/dgx_station/response.json
+++ b/client/test_data/amd64/dgx_station/response.json
@@ -1,5 +1,6 @@
 {
   "status": "Certified",
+  "certified_url": "https://ubuntu.com/certified/201711-25989",
   "architecture": "amd64",
   "bios": {
     "vendor": "American Megatrends Inc.",

--- a/client/test_data/amd64/thinkstation_p620/response.json
+++ b/client/test_data/amd64/thinkstation_p620/response.json
@@ -1,5 +1,6 @@
 {
   "status": "Certified",
+  "certified_url": "https://ubuntu.com/certified/202203-30052",
   "architecture": "amd64",
   "bios": {
     "vendor": "Lenovo",

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -52,45 +52,55 @@ fn assert_response_matches_expected(
     response: &CertificationStatusResponse,
     expected: &CertificationStatusResponse,
 ) {
-    let (actual_arch, actual_bios, actual_board, actual_releases) = match response {
-        CertificationStatusResponse::Certified {
-            architecture,
-            bios,
-            board,
-            available_releases,
-            ..
-        }
-        | CertificationStatusResponse::CertifiedImageExists {
-            architecture,
-            bios,
-            board,
-            available_releases,
-            ..
-        } => (architecture, bios, board, available_releases),
-        _ => panic!(
-            "Expected response to be Certified or Certified Image Exists, but it was {:?}",
-            response
-        ),
-    };
+    let (actual_certified_url, actual_arch, actual_bios, actual_board, actual_releases) =
+        match response {
+            CertificationStatusResponse::Certified {
+                certified_url,
+                architecture,
+                bios,
+                board,
+                available_releases,
+                ..
+            }
+            | CertificationStatusResponse::CertifiedImageExists {
+                certified_url,
+                architecture,
+                bios,
+                board,
+                available_releases,
+                ..
+            } => (certified_url, architecture, bios, board, available_releases),
+            _ => panic!(
+                "Expected response to be Certified or Certified Image Exists, but it was {:?}",
+                response
+            ),
+        };
 
-    let (expected_arch, expected_bios, expected_board, expected_releases) = match expected {
-        CertificationStatusResponse::Certified {
-            architecture,
-            bios,
-            board,
-            available_releases,
-            ..
-        }
-        | CertificationStatusResponse::CertifiedImageExists {
-            architecture,
-            bios,
-            board,
-            available_releases,
-            ..
-        } => (architecture, bios, board, available_releases),
-        _ => panic!("Expected response must contain Certified or CertifiedImageExists status"),
-    };
+    let (expected_certified_url, expected_arch, expected_bios, expected_board, expected_releases) =
+        match expected {
+            CertificationStatusResponse::Certified {
+                certified_url,
+                architecture,
+                bios,
+                board,
+                available_releases,
+                ..
+            }
+            | CertificationStatusResponse::CertifiedImageExists {
+                certified_url,
+                architecture,
+                bios,
+                board,
+                available_releases,
+                ..
+            } => (certified_url, architecture, bios, board, available_releases),
+            _ => panic!("Expected response must contain Certified or CertifiedImageExists status"),
+        };
 
+    assert_eq!(
+        actual_certified_url, expected_certified_url,
+        "Certified URL mismatch"
+    );
     assert_eq!(actual_arch, expected_arch, "Architecture mismatch");
     assert_eq!(actual_bios, expected_bios, "BIOS mismatch");
     assert_eq!(actual_board, expected_board, "Board mismatch");

--- a/server/hwapi/endpoints/certification/response_builders.py
+++ b/server/hwapi/endpoints/certification/response_builders.py
@@ -23,6 +23,10 @@ from hwapi.endpoints.certification.response_validators import (
     CertifiedResponse,
     RelatedCertifiedSystemExistsResponse,
 )
+from hwapi.external.certified.urls import (
+    get_certified_configuration_url,
+    get_certified_platform_url,
+)
 
 
 def build_related_certified_response(
@@ -33,6 +37,7 @@ def build_related_certified_response(
     releases: list[models.Release],
     kernels: list[models.Kernel],
 ) -> RelatedCertifiedSystemExistsResponse:
+    certified_url = get_certified_platform_url(machine.configuration.platform_id)
     architecture = repository.get_machine_architecture(db, machine.id)
     bios_validator = (
         data_validators.BiosValidator(
@@ -48,6 +53,7 @@ def build_related_certified_response(
         else None
     )
     return RelatedCertifiedSystemExistsResponse(
+        certified_url=certified_url,
         architecture=architecture,
         board=data_validators.BoardValidator(
             manufacturer=board.vendor.name,
@@ -79,6 +85,7 @@ def build_certified_response(
     releases: list[models.Release],
     kernels: list[models.Kernel],
 ) -> CertifiedResponse:
+    certified_url = get_certified_configuration_url(machine.canonical_id)
     architecture = repository.get_machine_architecture(db, machine.id)
     releases, kernels = repository.get_releases_and_kernels_for_machine(db, machine.id)
     bios_validator = (
@@ -95,6 +102,7 @@ def build_certified_response(
         else None
     )
     return CertifiedResponse(
+        certified_url=certified_url,
         architecture=architecture,
         board=data_validators.BoardValidator(
             manufacturer=board.vendor.name,
@@ -126,6 +134,7 @@ def build_certified_image_exists_response(
     releases: list[models.Release],
     kernels: list[models.Kernel],
 ) -> CertifiedImageExistsResponse:
+    certified_url = get_certified_configuration_url(machine.canonical_id)
     architecture = repository.get_machine_architecture(db, machine.id)
     bios_validator = (
         data_validators.BiosValidator(
@@ -141,6 +150,7 @@ def build_certified_image_exists_response(
         else None
     )
     return CertifiedImageExistsResponse(
+        certified_url=certified_url,
         architecture=architecture,
         board=data_validators.BoardValidator(
             manufacturer=board.vendor.name,

--- a/server/hwapi/endpoints/certification/response_validators.py
+++ b/server/hwapi/endpoints/certification/response_validators.py
@@ -18,7 +18,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from hwapi.data_models.data_validators import (
     AudioValidator,
@@ -38,6 +38,10 @@ from hwapi.data_models.enums import CertificationStatus
 
 class CertifiedResponse(BaseModel):
     status: Literal[CertificationStatus.CERTIFIED] = CertificationStatus.CERTIFIED
+
+    certified_url: str = Field(title="Certified URL")
+    """Link to relevant ubuntu.com/certified page."""
+
     architecture: str
     bios: BiosValidator | None
     board: BoardValidator
@@ -53,6 +57,10 @@ class RelatedCertifiedSystemExistsResponse(BaseModel):
     status: Literal[CertificationStatus.RELATED_CERTIFIED_SYSTEM_EXISTS] = (
         CertificationStatus.RELATED_CERTIFIED_SYSTEM_EXISTS
     )
+
+    certified_url: str = Field(title="Certified URL")
+    """Link to relevant ubuntu.com/certified page."""
+
     architecture: str
     board: BoardValidator
     bios: BiosValidator | None
@@ -71,6 +79,10 @@ class CertifiedImageExistsResponse(BaseModel):
     status: Literal[CertificationStatus.CERTIFIED_IMAGE_EXISTS] = (
         CertificationStatus.CERTIFIED_IMAGE_EXISTS
     )
+
+    certified_url: str = Field(title="Certified URL")
+    """Link to relevant ubuntu.com/certified page."""
+
     architecture: str
     bios: BiosValidator | None
     board: BoardValidator

--- a/server/hwapi/external/certified/urls.py
+++ b/server/hwapi/external/certified/urls.py
@@ -1,0 +1,17 @@
+"""This module contains the ubuntu.com/certified URLs."""
+
+BASE_URL = "https://ubuntu.com/certified"
+
+
+def get_certified_platform_url(platform_id: int) -> str:
+    """Build the certified platform URL."""
+    return f"{BASE_URL}/platforms/{platform_id}"
+
+
+def get_certified_configuration_url(canonical_id: str) -> str:
+    """Build the certified configuration URL.
+
+    Currently ubuntu.com/certified doesn't have a true configuration page,
+    instead using the Canonical ID of the machine linked to a certificate.
+    """
+    return f"{BASE_URL}/{canonical_id}"

--- a/server/schemas/openapi.yaml
+++ b/server/schemas/openapi.yaml
@@ -129,6 +129,9 @@ components:
           - type: 'null'
         board:
           $ref: '#/components/schemas/BoardValidator'
+        certified_url:
+          title: Certified URL
+          type: string
         chassis:
           anyOf:
           - $ref: '#/components/schemas/ChassisValidator'
@@ -139,6 +142,7 @@ components:
           title: Status
           type: string
       required:
+      - certified_url
       - architecture
       - bios
       - board
@@ -161,6 +165,9 @@ components:
           - type: 'null'
         board:
           $ref: '#/components/schemas/BoardValidator'
+        certified_url:
+          title: Certified URL
+          type: string
         chassis:
           anyOf:
           - $ref: '#/components/schemas/ChassisValidator'
@@ -171,6 +178,7 @@ components:
           title: Status
           type: string
       required:
+      - certified_url
       - architecture
       - bios
       - board
@@ -391,6 +399,9 @@ components:
           - type: 'null'
         board:
           $ref: '#/components/schemas/BoardValidator'
+        certified_url:
+          title: Certified URL
+          type: string
         chassis:
           anyOf:
           - $ref: '#/components/schemas/ChassisValidator'
@@ -441,6 +452,7 @@ components:
           - type: 'null'
           title: Wireless
       required:
+      - certified_url
       - architecture
       - board
       - bios

--- a/server/tests/data_generator.py
+++ b/server/tests/data_generator.py
@@ -21,6 +21,10 @@ from sqlalchemy.orm import Session
 
 from hwapi.data_models import models
 from hwapi.data_models.enums import BusType, DeviceCategory
+from hwapi.external.certified.urls import (
+    get_certified_configuration_url,
+    get_certified_platform_url,
+)
 
 NOW = datetime.now()
 NOW_DATE = NOW.date()
@@ -274,6 +278,7 @@ class CertificationStatusTestHelper:
     @staticmethod
     def assert_certified_response(
         response,
+        machine: models.Machine,
         board: models.Device,
         bios: models.Bios | None,
         release: models.Release,
@@ -282,6 +287,7 @@ class CertificationStatusTestHelper:
         assert response.status_code == 200
         assert response.json() == {
             "status": "Certified",
+            "certified_url": get_certified_configuration_url(machine.canonical_id),
             "architecture": "amd64",
             "board": {
                 "manufacturer": board.vendor.name,
@@ -312,6 +318,7 @@ class CertificationStatusTestHelper:
     @staticmethod
     def assert_certified_image_exists_response(
         response,
+        machine: models.Machine,
         board: models.Device,
         bios: models.Bios | None,
         release: models.Release,
@@ -320,6 +327,7 @@ class CertificationStatusTestHelper:
         assert response.status_code == 200
         assert response.json() == {
             "status": "Certified Image Exists",
+            "certified_url": get_certified_configuration_url(machine.canonical_id),
             "architecture": "amd64",
             "board": {
                 "manufacturer": board.vendor.name,
@@ -350,6 +358,7 @@ class CertificationStatusTestHelper:
     @staticmethod
     def assert_related_certified_system_exists_response(
         response,
+        platform: models.Platform,
         board: models.Device,
         bios: models.Bios | None,
         release: models.Release,
@@ -358,6 +367,7 @@ class CertificationStatusTestHelper:
         assert response.status_code == 200
         assert response.json() == {
             "status": "Related Certified System Exists",
+            "certified_url": get_certified_platform_url(platform.id),
             "architecture": "amd64",
             "board": {
                 "manufacturer": board.vendor.name,

--- a/server/tests/endpoints/certification/test_certification.py
+++ b/server/tests/endpoints/certification/test_certification.py
@@ -120,7 +120,7 @@ def test_disqualifying_hardware(generator: DataGenerator, test_client: TestClien
     response = test_client.post("/v1/certification/status", json=request)
 
     CertificationStatusTestHelper.assert_related_certified_system_exists_response(
-        response, board, bios, release, report.kernel
+        response, machine.configuration.platform, board, bios, release, report.kernel
     )
 
 
@@ -156,7 +156,7 @@ def test_correct_hardware_unmatching_os(
     response = test_client.post("/v1/certification/status", json=request)
 
     CertificationStatusTestHelper.assert_certified_image_exists_response(
-        response, board, bios, focal, report.kernel
+        response, machine, board, bios, focal, report.kernel
     )
 
 
@@ -190,7 +190,7 @@ def test_all_criteria_matched(generator: DataGenerator, test_client: TestClient)
     response = test_client.post("/v1/certification/status", json=request)
 
     CertificationStatusTestHelper.assert_certified_response(
-        response, board, bios, release, report.kernel
+        response, machine, board, bios, release, report.kernel
     )
 
 
@@ -228,7 +228,7 @@ def test_match_with_board_as_system(generator: DataGenerator, test_client: TestC
     response = test_client.post("/v1/certification/status", json=request)
 
     CertificationStatusTestHelper.assert_certified_response(
-        response, board, bios, release, report.kernel
+        response, machine, board, bios, release, report.kernel
     )
 
 
@@ -260,7 +260,7 @@ def test_bios_is_none(generator: DataGenerator, test_client: TestClient):
     response = test_client.post("/v1/certification/status", json=request)
 
     CertificationStatusTestHelper.assert_certified_response(
-        response, board, bios=None, release=release, kernel=report.kernel
+        response, machine, board, bios=None, release=release, kernel=report.kernel
     )
 
 
@@ -288,7 +288,7 @@ def test_cpu_id_is_none(generator: DataGenerator, test_client: TestClient):
     response = test_client.post("/v1/certification/status", json=request)
 
     CertificationStatusTestHelper.assert_certified_response(
-        response, board, bios=None, release=release, kernel=report.kernel
+        response, machine, board, bios=None, release=release, kernel=report.kernel
     )
 
 
@@ -330,5 +330,5 @@ def test_hardware_matches_multiple_bios(
     response = test_client.post("/v1/certification/status", json=request)
 
     CertificationStatusTestHelper.assert_certified_response(
-        response, board, bios, release, report.kernel
+        response, machine, board, bios, release, report.kernel
     )

--- a/server/tests/external/certified/test_urls.py
+++ b/server/tests/external/certified/test_urls.py
@@ -1,0 +1,20 @@
+"""Tests for the ubuntu.com/certified URLs."""
+
+from hwapi.external.certified.urls import (
+    get_certified_configuration_url,
+    get_certified_platform_url,
+)
+
+
+def test_get_certified_platform_url():
+    """Tests that the public platform URL is valid."""
+    platform_id = 123
+    url = get_certified_platform_url(platform_id)
+    assert url == f"https://ubuntu.com/certified/platforms/{platform_id}"
+
+
+def test_get_certified_configuration_url():
+    """Tests that the public configuration URL is valid."""
+    canonical_id = "202512-30000"
+    url = get_certified_configuration_url(canonical_id)
+    assert url == f"https://ubuntu.com/certified/{canonical_id}"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR adds a `certified_url` link to the relevant public certified page to the certified responses (certified, related system, and certified image)
- This change improves user experience by providing some transparency as to where they can find the (public) certification data.

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->

Fixes [HWAPI-59](https://warthogs.atlassian.net/browse/HWAPI-59)

## Testing

<!-- Describe the tests you ran to verify your changes. -->

- Unit tests updated
- Manual testing steps:

  1. Set up development environment (e.g., with test db seed)
  2. Check certification on certified system
  3. Response should include a ubuntu.com/certified link in response's `certified_url`

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [x] I have followed the [contribution guidelines].
- [x] I have signed the [Canonical CLA][cla].
- [x] I have added necessary tests.
- [x] I have added or updated any relevant documentation (if needed).
- [x] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors


[HWAPI-59]: https://warthogs.atlassian.net/browse/HWAPI-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ