### PR TITLE
ci: Update codecov components configuration

### DIFF
--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -58,7 +58,6 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           files: client/coverage.xml
-          flags: client
           token: ${{ secrets.CODECOV_TOKEN }}
 
   py-bindings-test:

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -69,7 +69,6 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           files: server/coverage/coverage.xml
-          flags: server
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Check OpenAPI schema
         run: uvx tox run -e check-schema
@@ -136,7 +135,6 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           files: server/charm/coverage.xml
-          flags: server,charm
           token: ${{ secrets.CODECOV_TOKEN }}
 
   charm-integration:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -14,7 +14,10 @@ component_management:
   individual_components:
     - component_id: server
       name: Server
-      paths: [server/**]
+      paths: [server/**, "!server/charm/**"]
+    - component_id: charm
+      name: Charm
+      paths: [server/charm/**]
     - component_id: client
       name: Client
       paths: [client/**]

--- a/server/charm/README.md
+++ b/server/charm/README.md
@@ -50,7 +50,7 @@ The Hardware API Charm is released under the [Apache-2.0 license](LICENSE).
 [charmcraft-site]: https://charmhub.io/hardware-api
 [test-badge]: https://github.com/canonical/hardware-api/actions/workflows/test_server.yaml/badge.svg
 [test-site]: https://github.com/canonical/hardware-api/actions/workflows/test_server.yaml
-[cov-badge]: https://codecov.io/gh/canonical/hardware-api/graph/badge.svg?token=p0h9tTp2F3&component=server&flags=charm
+[cov-badge]: https://codecov.io/gh/canonical/hardware-api/graph/badge.svg?token=p0h9tTp2F3&component=charm
 [cov-latest]: https://codecov.io/gh/canonical/hardware-api
 [uv-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
 [uv-site]: https://github.com/astral-sh/uv


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR updates the codecov configuration to separate the server and charm components
- The CI keeps "failing" and then passing because the Charm and server unit tests run separately. Moreover, they are technically different products that we should test separately.

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->

Untracked

## Testing

<!-- Describe the tests you ran to verify your changes. -->

- Unit tests
- Manual testing steps: n/a (look at codecov comment in this PR)

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [X] I have added necessary tests.
- [X] I have added or updated any relevant documentation (if needed).
- [X] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
