### PR TITLE
feat(charm): Add Traefik relation

### DIFF
--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -38,6 +38,9 @@ requires:
   nginx-route:
     interface: nginx-route
     limit: 1
+  traefik-route:
+    interface: traefik_route
+    limit: 1
 
 charm-libs:
   - lib: traefik_k8s.traefik_route

--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -37,6 +37,7 @@ resources:
 requires:
   nginx-route:
     interface: nginx-route
+    limit: 1
 
 charm-libs:
   - lib: nginx_ingress_integrator.nginx_route

--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -40,6 +40,8 @@ requires:
     limit: 1
 
 charm-libs:
+  - lib: traefik_k8s.traefik_route
+    version: "0"
   - lib: nginx_ingress_integrator.nginx_route
     version: "0"
 

--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -73,7 +73,11 @@ config:
       default: 30000
       description: The port to listen on for incoming HTTP requests.
       type: int
+    # TODO: Remove once NGINX support is dropped
     hostname:
       default: hw
-      description: External hostname for the service.
+      description: >
+        External hostname for the service.
+        This is only used when exposing the service with NGINX. For Traefik,
+        configure the Traefik `external_hostname` option.
       type: string

--- a/server/charm/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/server/charm/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for traefik_route.
+
+This library wraps relation endpoints for traefik_route. The requirer of this
+relation is the traefik-route-k8s charm, or any charm capable of providing
+Traefik configuration files. The provider is the traefik-k8s charm, or another
+charm willing to consume Traefik configuration files.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route
+```
+
+To use the library from the provider side (Traefik):
+
+```yaml
+provides:
+    traefik_route:
+        interface: traefik_route
+        limit: 1
+```
+
+```python
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteProvider
+
+class TraefikCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.traefik_route = TraefikRouteProvider(self)
+
+    self.framework.observe(
+        self.traefik_route.on.ready, self._handle_traefik_route_ready
+    )
+
+    def _handle_traefik_route_ready(self, event):
+        config: str = self.traefik_route.get_config(event.relation)  # yaml
+        # use config to configure Traefik
+```
+
+To use the library from the requirer side (TraefikRoute):
+
+```yaml
+requires:
+    traefik-route:
+        interface: traefik_route
+        limit: 1
+        optional: false
+```
+
+Example usage without raw flag (default behavior):
+
+```python
+# ...
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
+
+class TraefikRouteCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    traefik_route = TraefikRouteRequirer(
+        self, self.model.relations.get("traefik-route"),
+        "traefik-route",
+        raw=False  # Default: Traefik will append TLS configs
+    )
+    if traefik_route.is_ready():
+        traefik_route.submit_to_traefik(
+            config={'my': {'traefik': 'configuration'}}
+        )
+```
+
+Example usage with raw flag enabled (full control over TLS configuration):
+
+```python
+# ...
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
+
+class TraefikRouteCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    traefik_route = TraefikRouteRequirer(
+        self, self.model.relations.get("traefik-route"),
+        "traefik-route",
+        raw=True  # Traefik will not modify TLS settings on all routes
+    )
+    if self.traefik_route.is_ready():
+        self.traefik_route.submit_to_traefik(
+            config={
+                'tcp': {
+                    'routers': {
+                        'secure-route': {
+                            'rule': 'Host(`secure.example.com`)',
+                            'service': 'my-service',
+                            'tls': {'certResolver': 'myresolver'}
+                        }
+                    }
+                }
+            }
+        )
+```
+"""
+
+import logging
+from typing import Optional
+
+import yaml
+from ops.charm import CharmBase, CharmEvents, RelationEvent
+from ops.framework import EventSource, Object, StoredState
+from ops.model import Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "f0d93d2bdf354b99a527463a9c49fce3"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 5
+
+log = logging.getLogger(__name__)
+
+
+class TraefikRouteException(RuntimeError):
+    """Base class for exceptions raised by TraefikRoute."""
+
+
+class UnauthorizedError(TraefikRouteException):
+    """Raised when the unit needs leadership to perform some action."""
+
+
+class TraefikRouteProviderReadyEvent(RelationEvent):
+    """Event emitted when Traefik is ready to provide ingress for a routed unit."""
+
+
+class TraefikRouteProviderDataRemovedEvent(RelationEvent):
+    """Event emitted when a routed ingress relation is removed."""
+
+
+class TraefikRouteRequirerReadyEvent(RelationEvent):
+    """Event emitted when a unit requesting ingress has provided all data Traefik needs."""
+
+
+class TraefikRouteRequirerEvents(CharmEvents):
+    """Container for TraefikRouteRequirer events."""
+
+    ready = EventSource(TraefikRouteRequirerReadyEvent)
+
+
+class TraefikRouteProviderEvents(CharmEvents):
+    """Container for TraefikRouteProvider events."""
+
+    ready = EventSource(TraefikRouteProviderReadyEvent)  # TODO rename to data_provided in v1
+    data_removed = EventSource(TraefikRouteProviderDataRemovedEvent)
+
+
+class TraefikRouteProvider(Object):
+    """Implementation of the provider of traefik_route.
+
+    This will presumably be owned by a Traefik charm.
+    The main idea is that Traefik will observe the `ready` event and, upon
+    receiving it, will fetch the config from the TraefikRoute's application databag,
+    apply it, and update its own app databag to let Route know that the ingress
+    is there.
+    The TraefikRouteProvider provides api to do this easily.
+    """
+
+    on = TraefikRouteProviderEvents()  # pyright: ignore
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = "traefik-route",
+        external_host: str = "",
+        *,
+        scheme: str = "http",
+    ):
+        """Constructor for TraefikRouteProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation relation_name to bind to
+                (defaults to "traefik-route").
+            external_host: The external host.
+            scheme: The scheme.
+        """
+        super().__init__(charm, relation_name)
+        self._stored.set_default(external_host=None, scheme=None)
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        if (
+            self._stored.external_host != external_host  # pyright: ignore
+            or self._stored.scheme != scheme  # pyright: ignore
+        ):
+            # If traefik endpoint details changed, update
+            self.update_traefik_address(external_host=external_host, scheme=scheme)
+
+        self.framework.observe(
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_broken, self._on_relation_broken
+        )
+
+    @property
+    def external_host(self) -> str:
+        """Return the external host set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.external_host or ""  # type: ignore
+
+    @property
+    def scheme(self) -> str:
+        """Return the scheme set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.scheme or ""  # type: ignore
+
+    @property
+    def relations(self) -> list:
+        """The list of Relation instances associated with this endpoint."""
+        return list(self._charm.model.relations[self._relation_name])
+
+    def _update_stored(self) -> None:
+        """Ensure that the stored data is up-to-date.
+
+        This is split out into a separate method since, in the case of multi-unit deployments,
+        removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on
+        app data ensures that only the previous leader will know what it is. Separating it
+        allows for reuse both when the property is called and if the relation changes, so a
+        leader change where the new leader checks the property will do the right thing.
+        """
+        if not self._charm.unit.is_leader():
+            return
+
+        for relation in self._charm.model.relations[self._relation_name]:
+            if not relation.app:
+                self._stored.external_host = ""
+                self._stored.scheme = ""
+                return
+            external_host = relation.data[relation.app].get("external_host", "")
+            self._stored.external_host = (
+                external_host or self._stored.external_host  # pyright: ignore
+            )
+            scheme = relation.data[relation.app].get("scheme", "")
+            self._stored.scheme = scheme or self._stored.scheme  # pyright: ignore
+
+    def _on_relation_changed(self, event: RelationEvent) -> None:
+        if self.is_ready(event.relation):
+            # todo check data is valid here?
+            self.update_traefik_address()
+            self.on.ready.emit(relation=event.relation, app=event.relation.app)
+
+    def _on_relation_broken(self, event: RelationEvent) -> None:
+        self.on.data_removed.emit(relation=event.relation, app=event.relation.app)
+
+    def update_traefik_address(
+        self, *, external_host: Optional[str] = None, scheme: Optional[str] = None
+    ) -> None:
+        """Ensure that requirers know the external host for Traefik."""
+        if not self._charm.unit.is_leader():
+            return
+
+        for relation in self._charm.model.relations[self._relation_name]:
+            relation.data[self._charm.app]["external_host"] = external_host or self.external_host
+            relation.data[self._charm.app]["scheme"] = scheme or self.scheme
+
+        # We first attempt to write relation data (which may raise) and only then update stored
+        # state.
+        self._stored.external_host = external_host
+        self._stored.scheme = scheme
+
+    def is_ready(self, relation: Relation) -> bool:
+        """Whether TraefikRoute is ready on this relation.
+
+        Returns True when the remote app shared the config; False otherwise.
+        """
+        if not relation.app or not relation.data[relation.app]:
+            return False
+        return "config" in relation.data[relation.app]
+
+    def get_config(self, relation: Relation) -> Optional[str]:
+        """Renamed to ``get_dynamic_config``."""
+        log.warning(
+            "``TraefikRouteProvider.get_config`` is deprecated. "
+            "Use ``TraefikRouteProvider.get_dynamic_config`` instead"
+        )
+        return self.get_dynamic_config(relation)
+
+    def get_dynamic_config(self, relation: Relation) -> Optional[str]:
+        """Retrieve the dynamic config published by the remote application."""
+        if not self.is_ready(relation):
+            return None
+        return relation.data[relation.app].get("config")
+
+    def is_raw_enabled(self, relation: Relation) -> bool:
+        """Check if the raw config mode is enabled by the remote application."""
+        if not self.is_ready(relation):
+            return False
+        return relation.data[relation.app].get("raw") == "True"
+
+    def get_static_config(self, relation: Relation) -> Optional[str]:
+        """Retrieve the static config published by the remote application."""
+        if not self.is_ready(relation):
+            return None
+        return relation.data[relation.app].get("static")
+
+
+class TraefikRouteRequirer(Object):
+    """Handles the requirer side of the traefik-route interface.
+
+    This class provides an API for publishing dynamic and static configurations
+    to the Traefik charm through the `traefik-route` relation. It does not perform
+    validation on the provided configurations, assuming that Traefik will handle
+    valid YAML-encoded data.
+
+    The application databag follows the structure:
+
+    ```json
+    {
+        "config": "<Traefik dynamic config YAML>",
+        "static": "<Traefik static config YAML>",  # Optional, requires Traefik restart
+        "raw": "<bool>"  # Determines if Traefik should append TLS config for ALL routes
+    }
+    ```
+
+    """
+
+    on = TraefikRouteRequirerEvents()  # pyright: ignore
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation: Relation,
+        relation_name: str = "traefik-route",
+        raw: Optional[bool] = False,
+    ):
+        """Initialize the traefik-route requirer class.
+
+        Args:
+            charm: Requirer charm.
+            relation: traefik-route relation.
+            relation_name: Name of the relation. Defaults to "traefik-route".
+            raw: Whether or not to enable raw mode. Defaults to False.
+        """
+        super(TraefikRouteRequirer, self).__init__(charm, relation_name)
+        self._stored.set_default(external_host=None, scheme=None)
+
+        self._charm = charm
+        self._relation = relation
+        self._raw = raw
+
+        if self._raw:
+            log.warning(
+                "Raw mode enabled: TLS routes for ALL protocols will not be auto-generated. "
+                "Enable this only if you fully understand and intend to bypass the additional"
+                "TLS configuration."
+            )
+
+        self.framework.observe(
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_broken, self._on_relation_broken
+        )
+
+    @property
+    def external_host(self) -> str:
+        """Return the external host set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.external_host or ""  # type: ignore
+
+    @property
+    def scheme(self) -> str:
+        """Return the scheme set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.scheme or ""  # type: ignore
+
+    def _update_stored(self) -> None:
+        """Ensure that the stored host is up-to-date.
+
+        This is split out into a separate method since, in the case of multi-unit deployments,
+        removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on
+        app data ensures that only the previous leader will know what it is. Separating it
+        allows for reuse both when the property is called and if the relation changes, so a
+        leader change where the new leader checks the property will do the right thing.
+        """
+        if not self._charm.unit.is_leader():
+            return
+
+        if self._relation:
+            for relation in self._charm.model.relations[self._relation.name]:
+                if not relation.app:
+                    self._stored.external_host = ""
+                    self._stored.scheme = ""
+                    return
+                external_host = relation.data[relation.app].get("external_host", "")
+                self._stored.external_host = (
+                    external_host or self._stored.external_host  # pyright: ignore
+                )
+                scheme = relation.data[relation.app].get("scheme", "")
+                self._stored.scheme = scheme or self._stored.scheme  # pyright: ignore
+
+    def _on_relation_changed(self, event: RelationEvent) -> None:
+        """Update StoredState with external_host and other information from Traefik."""
+        self._update_stored()
+        if self._charm.unit.is_leader():
+            self.on.ready.emit(relation=event.relation, app=event.relation.app)
+
+    def _on_relation_broken(self, event: RelationEvent) -> None:
+        """On RelationBroken, clear the stored data if set and emit an event."""
+        self._stored.external_host = ""
+        if self._charm.unit.is_leader():
+            self.on.ready.emit(relation=event.relation, app=event.relation.app)
+
+    def is_ready(self) -> bool:
+        """Is the TraefikRouteRequirer ready to submit data to Traefik?"""
+        return self._relation is not None
+
+    def submit_to_traefik(self, config: dict, static: Optional[dict] = None) -> None:
+        """Submit an ingress configuration to Traefik.
+
+        This method publishes dynamic and static configuration data to the
+        `traefik-route` relation, allowing Traefik to pick up and apply the settings.
+
+        - **Dynamic config (`config`)**: Defines routing rules for Traefik.
+        - **Static config (`static`)**: Requires a Traefik restart to take effect.
+
+        Raises:
+            UnauthorizedError: If the unit is not the leader.
+        """
+        if not self._charm.unit.is_leader():
+            raise UnauthorizedError()
+
+        app_databag = self._relation.data[self._charm.app]
+
+        app_databag["raw"] = str(self._raw)
+
+        # Traefik thrives on YAML, feels pointless to talk JSON to Route
+        app_databag["config"] = yaml.safe_dump(config)
+
+        if static:
+            app_databag["static"] = yaml.safe_dump(static)

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -22,7 +22,7 @@ class HardwareApiConfig(pydantic.BaseModel):
 
     log_level: Literal["info", "debug", "warning", "error", "critical"] = "info"
     port: int = 30000
-    hostname: str = "str"
+    hostname: str = "hw"
 
 
 class HardwareApiCharm(ops.CharmBase):

--- a/server/charm/tests/integration/helpers.py
+++ b/server/charm/tests/integration/helpers.py
@@ -3,6 +3,7 @@
 
 import functools
 import logging
+import subprocess
 import time
 from urllib.parse import urlparse
 
@@ -49,6 +50,23 @@ def app_is_up(base_url: str, session: requests.Session | None = None) -> bool:
     if not ok:
         logger.error("Response: %s", response)
     return ok
+
+
+def get_k8s_ingress_ip(model_name: str, service_name: str) -> str:
+    """Get the external IP of a Kubernetes service LoadBalancer."""
+    return subprocess.check_output(
+        [
+            "kubectl",
+            "get",
+            "service",
+            service_name,
+            "--namespace",
+            model_name,
+            "--output",
+            "jsonpath={.status.loadBalancer.ingress[0].ip}",
+        ],
+        text=True,
+    ).strip()
 
 
 def retry(retry_num: int, retry_sleep_sec: int):

--- a/server/charm/tests/integration/test_nginx.py
+++ b/server/charm/tests/integration/test_nginx.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (C) 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
+# TODO: Remove once NGINX support is dropped
 """Integration tests for the Hardware API Charm behind NGINX."""
 
 import logging

--- a/server/charm/tests/integration/test_traefik.py
+++ b/server/charm/tests/integration/test_traefik.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Integration tests for the Hardware API Charm behind Traefik."""
+
+import logging
+from pathlib import Path
+
+import jubilant
+import requests
+import yaml
+
+from .helpers import DNSResolverHTTPAdapter, app_is_up, get_k8s_ingress_ip, retry
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("charmcraft.yaml").read_text(encoding="utf-8"))
+APP_NAME = METADATA["name"]
+PORT = 80
+INGRESS_NAME = "ingress"
+EXTERNAL_HOSTNAME = "hw.internal"
+
+
+def test_deploy_ingress(charm: Path, juju: jubilant.Juju):
+    """Deploy the charm under test and the ingress charm."""
+    upstream_source = METADATA["resources"]["hardware-api-image"]["upstream-source"]
+    resources = {"hardware-api-image": upstream_source}
+    config = {"port": PORT}
+    juju.deploy(charm.resolve(), app=APP_NAME, resources=resources, config=config)
+
+    config = {"external_hostname": EXTERNAL_HOSTNAME}
+    juju.deploy(
+        "traefik-k8s", channel="latest/stable", app=INGRESS_NAME, config=config, trust=True
+    )
+    juju.integrate(f"{APP_NAME}:traefik-route", f"{INGRESS_NAME}:traefik-route")
+    juju.wait(jubilant.all_active)
+
+
+@retry(retry_num=5, retry_sleep_sec=5)
+def test_ingress_is_up(juju: jubilant.Juju):
+    """Test that the application is reachable via the ingress."""
+    model = juju.show_model()
+    ingress_ip = get_k8s_ingress_ip(model.short_name, f"{INGRESS_NAME}-lb")
+    session = requests.Session()
+    dns_resolver = DNSResolverHTTPAdapter(EXTERNAL_HOSTNAME, ingress_ip)
+    session.mount("http://", dns_resolver)
+    session.mount("https://", dns_resolver)
+    base_url = f"http://{EXTERNAL_HOSTNAME}"
+    assert app_is_up(base_url, session=session)

--- a/server/charm/tests/unit/conftest.py
+++ b/server/charm/tests/unit/conftest.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2026 Canonical Ltd.
 """Testing fixtures."""
 
+import json
+
 import pytest
 from ops import testing
 
@@ -11,3 +13,15 @@ from charm import HardwareApiCharm
 def ctx() -> testing.Context:
     """Create the Hardware API Charm context."""
     return testing.Context(HardwareApiCharm)
+
+
+@pytest.fixture(scope="function")
+def ingress_template() -> str:
+    """Create a configuration for the traefik-k8s ingress."""
+    template = {
+        "model": "{{ model }}",
+        "app": "{{ app }}",
+        "public_port": "{{ public_port }}",
+        "external_hostname": "{{ external_hostname }}",
+    }
+    return json.dumps(template)

--- a/server/charm/tests/unit/test_charm.py
+++ b/server/charm/tests/unit/test_charm.py
@@ -5,7 +5,7 @@
 """Unit tests for Hardware API Charm."""
 
 import logging
-from unittest.mock import patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import ops
 import pytest
@@ -94,3 +94,85 @@ def test_config_changed_updates_pebble_layer(ctx: testing.Context):
         state_out.get_container(container.name).service_statuses["hardware-api"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
+
+
+def test_blocked_status_on_multiple_ingress_providers(ctx: testing.Context):
+    """Tests that status is blocked when both ingress providers are connected."""
+    # TODO: Remove once NGINX support is dropped
+    container = testing.Container(name="hardware-api", can_connect=True)
+    traefik_relation = testing.Relation("traefik-route")
+    nginx_relation = testing.Relation("nginx-route")
+    state_in = testing.State(
+        containers={container},
+        leader=True,
+        relations={traefik_relation, nginx_relation},
+    )
+    state_out = ctx.run(ctx.on.relation_changed(traefik_relation), state_in)
+    assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+@patch("charm.TraefikRouteRequirer.submit_to_traefik")
+def test_route_relation_changed_not_leader(
+    patched_submit_to_traefik: MagicMock, ctx: testing.Context, ingress_template: str
+):
+    """Tests that non-leader units do not submit Traefik config."""
+    container = testing.Container(name="hardware-api", can_connect=True)
+    remote_app_data = {"external_host": "hw.local"}
+    relation = testing.Relation("traefik-route", remote_app_data=remote_app_data)
+    state_in = testing.State(containers={container}, relations={relation}, leader=False)
+    with patch("builtins.open", mock_open(read_data=ingress_template)):
+        ctx.run(ctx.on.relation_changed(relation), state_in)
+    patched_submit_to_traefik.assert_not_called()
+
+
+@patch("charm.TraefikRouteRequirer.submit_to_traefik")
+def test_route_relation_changed_not_ready(
+    patched_submit_to_traefik: MagicMock, ctx: testing.Context, ingress_template: str
+):
+    """Tests the route relation changed event is deferred when not ready."""
+    container = testing.Container(name="hardware-api", can_connect=True)
+    remote_app_data = {"external_host": "hw.local"}
+    relation = testing.Relation("traefik-route", remote_app_data=remote_app_data)
+    state_in = testing.State(containers={container}, relations={relation}, leader=True)
+    with (
+        patch("charm.TraefikRouteRequirer.is_ready", MagicMock(return_value=False)),
+        patch("builtins.open", mock_open(read_data=ingress_template)),
+    ):
+        ctx.run(ctx.on.relation_changed(relation), state_in)
+    patched_submit_to_traefik.assert_not_called()
+
+
+@patch("charm.TraefikRouteRequirer.submit_to_traefik")
+def test_route_relation_changed(
+    patched_submit_to_traefik: MagicMock, ctx: testing.Context, ingress_template: str
+):
+    """Tests the route relation changed event on success."""
+    container = testing.Container(name="hardware-api", can_connect=True)
+    remote_app_data = {"external_host": "hw.local"}
+    relation = testing.Relation("traefik-route", remote_app_data=remote_app_data)
+    state_in = testing.State(containers={container}, relations={relation}, leader=True)
+    with (
+        patch("builtins.open", mock_open(read_data=ingress_template)),
+        ctx(ctx.on.relation_changed(relation), state_in) as mgr,
+    ):
+        assert mgr.charm.traefik.is_ready()
+        assert mgr.charm.traefik._relation is not None
+    patched_submit_to_traefik.assert_called_once()
+
+
+@patch("charm.TraefikRouteRequirer.submit_to_traefik")
+def test_route_relation_broken(patched_submit_to_traefik: MagicMock, ctx: testing.Context):
+    """Tests the route relation changed event on success."""
+    # Test relation broken
+    container = testing.Container(name="hardware-api", can_connect=True)
+    remote_app_data = {"external_host": "hw.local"}
+    relation = testing.Relation("traefik-route", remote_app_data=remote_app_data)
+    state_in = testing.State(containers={container}, relations={relation}, leader=True)
+    ctx.run(ctx.on.relation_broken(relation), state_in)
+    patched_submit_to_traefik.assert_not_called()
+    # Test relation status after removal
+    state_in = testing.State(containers={container}, leader=True)
+    with ctx(ctx.on.update_status(), state_in) as mgr:
+        assert not mgr.charm.traefik.is_ready()
+        assert mgr.charm.traefik._relation is None
+    patched_submit_to_traefik.assert_not_called()


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR adds Traefik as an ingress option for the Hardware API Charm.
- NGINX is deprecated and most of our projects are turning to traefik as the ingress of choice. This PR allows the integration with Traefik, but will not break the existing NGINX deployments until a later date.

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->

Resolves [HWAPI-61](https://warthogs.atlassian.net/browse/HWAPI-61)

## Testing

<!-- Describe the tests you ran to verify your changes. -->

- Unit tests
- Integration tests
- Manual testing steps:

  1. Set up Juju environment
  2. Pack charm
  3. `uvx tox run -e unit,integration`

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [x] I have added necessary tests.
- [X] I have added or updated any relevant documentation (if needed).
- [x] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

This PR is non-breaking, adding Traefik as a choice instead of NGINX. Further work will eventually make Traefik the default in the Terraform modules and remove NGINX from the Charm.

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors


[HWAPI-61]: https://warthogs.atlassian.net/browse/HWAPI-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ