### PR TITLE
chore: Replace NGINX with Traefik in Terraform modules

### DIFF
--- a/server/terraform/charm/outputs.tf
+++ b/server/terraform/charm/outputs.tf
@@ -6,6 +6,7 @@ output "app_name" {
 output "endpoints" {
   description = "Map of all endpoints"
   value = {
-    nginx_route = "nginx-route"
+    nginx_route   = "nginx-route"
+    traefik_route = "traefik-route"
   }
 }

--- a/server/terraform/charm/variables.tf
+++ b/server/terraform/charm/variables.tf
@@ -1,6 +1,6 @@
 variable "app_name" {
   type        = string
-  default     = "api"
+  default     = "hwapi"
   description = "Name to give the deployed application"
 }
 

--- a/server/terraform/product/README.md
+++ b/server/terraform/product/README.md
@@ -39,27 +39,22 @@ deployment onto any Kubernetes environment managed by [Juju].
 | Name                                                          | Type        |
 | ------------------------------------------------------------- | ----------- |
 | [juju_model.hardware_api][juju_model]                         | data source |
-| [juju_application.nginx_ingress_integrator][juju_application] | resource    |
-| [juju_integration.hardware_api_ingress][juju_integration]     | resource    |
+| [juju_application.traefik_k8s][juju_application]              | resource    |
+| [juju_integration.traefik_k8s-hardware_api][juju_integration] | resource    |
 
 ## Inputs
 
-| Name                     | Description                                                                       | Type   |
-| ------------------------ | --------------------------------------------------------------------------------- | ------ |
-| model                    | Reference to an existing model resource or data source for the model to deploy to | string |
-| hardware_api             | n/a                                                                               | object |
-| nginx_ingress_integrator | n/a                                                                               | object |
+| Name         | Description                                                                       | Type   |
+| ------------ | --------------------------------------------------------------------------------- | ------ |
+| model        | Reference to an existing model resource or data source for the model to deploy to | string |
+| hardware_api | n/a                                                                               | object |
+| traefik_k8s  | n/a                                                                               | object |
 
 ## Outputs
 
-| Name                              | Description                                               |
-| --------------------------------- | --------------------------------------------------------- |
-| hardware_api_app_name             | Name of the deployed Hardware API application             |
-| hardware_api_requires             |                                                           |
-| hardware_api_provides             |                                                           |
-| nginx_ingress_integrator_app_name | Name of the deployed NGINX Ingress Integrator application |
-| nginx_ingress_integrator_requires |                                                           |
-| nginx_ingress_integrator_provides |                                                           |
+| Name         | Description                            |
+| ------------ | -------------------------------------- |
+| applications | The applications making up the product |
 
 [terraform]: https://terraform.io
 [hardware-api-charm]: https://charmhub.io/hardware-api

--- a/server/terraform/product/README.md
+++ b/server/terraform/product/README.md
@@ -41,6 +41,8 @@ deployment onto any Kubernetes environment managed by [Juju].
 | [juju_model.hardware_api][juju_model]                         | data source |
 | [juju_application.traefik_k8s][juju_application]              | resource    |
 | [juju_integration.traefik_k8s-hardware_api][juju_integration] | resource    |
+| [juju_application.lego][juju_application]                     | resource    |
+| [juju_integration.lego-traefik_k8s][juju_integration]         | resource    |
 
 ## Inputs
 
@@ -49,6 +51,7 @@ deployment onto any Kubernetes environment managed by [Juju].
 | model        | Reference to an existing model resource or data source for the model to deploy to | string |
 | hardware_api | n/a                                                                               | object |
 | traefik_k8s  | n/a                                                                               | object |
+| lego         | n/a                                                                               | object |
 
 ## Outputs
 

--- a/server/terraform/product/main.tf
+++ b/server/terraform/product/main.tf
@@ -14,27 +14,27 @@ module "hardware_api" {
   units       = var.hardware_api.units
 }
 
-resource "juju_application" "nginx_ingress_integrator" {
-  name  = var.nginx_ingress_integrator.app_name
+resource "juju_application" "traefik_k8s" {
+  name  = var.traefik_k8s.app_name
   model = data.juju_model.hardware_api.name
   trust = true
   charm {
-    name     = "nginx-ingress-integrator"
-    channel  = var.nginx_ingress_integrator.channel
-    revision = var.nginx_ingress_integrator.revision
+    name     = "traefik-k8s"
+    channel  = var.traefik_k8s.channel
+    revision = var.traefik_k8s.revision
   }
-  units  = var.nginx_ingress_integrator.units
-  config = var.nginx_ingress_integrator.config
+  units  = 1
+  config = var.traefik_k8s.config
 }
 
-resource "juju_integration" "hardware_api_ingress" {
+resource "juju_integration" "traefik_k8s-hardware_api" {
   model = data.juju_model.hardware_api.name
   application {
-    name     = module.hardware_api.app_name
-    endpoint = module.hardware_api.endpoints.nginx_route
+    name     = juju_application.traefik_k8s.name
+    endpoint = "traefik-route"
   }
   application {
-    name     = juju_application.nginx_ingress_integrator.name
-    endpoint = "nginx-route"
+    name     = module.hardware_api.app_name
+    endpoint = module.hardware_api.endpoints.traefik_route
   }
 }

--- a/server/terraform/product/main.tf
+++ b/server/terraform/product/main.tf
@@ -38,3 +38,27 @@ resource "juju_integration" "traefik_k8s-hardware_api" {
     endpoint = module.hardware_api.endpoints.traefik_route
   }
 }
+
+resource "juju_application" "lego" {
+  name  = var.lego.app_name
+  model = data.juju_model.hardware_api.name
+  charm {
+    name     = "lego"
+    channel  = var.lego.channel
+    revision = var.lego.revision
+  }
+  units  = 1
+  config = var.lego.config
+}
+
+resource "juju_integration" "lego-traefik_k8s" {
+  model = data.juju_model.hardware_api.name
+  application {
+    name     = juju_application.lego.name
+    endpoint = "certificates"
+  }
+  application {
+    name     = juju_application.traefik_k8s.name
+    endpoint = "certificates"
+  }
+}

--- a/server/terraform/product/outputs.tf
+++ b/server/terraform/product/outputs.tf
@@ -2,5 +2,6 @@ output "applications" {
   value = {
     hardware_api = module.hardware_api
     traefik_k8s  = juju_application.traefik_k8s
+    lego         = juju_application.lego
   }
 }

--- a/server/terraform/product/outputs.tf
+++ b/server/terraform/product/outputs.tf
@@ -1,29 +1,6 @@
-output "hardware_api_app_name" {
-  description = "The name of the Hardware API application"
-  value       = module.hardware_api.app_name
-}
-
-output "hardware_api_requires" {
+output "applications" {
   value = {
-    nginx_route = "nginx-route"
-  }
-}
-
-output "hardware_api_provides" {
-  value = {}
-}
-
-output "nginx_ingress_integrator_app_name" {
-  description = "The name of the NGINX Ingress Integrator application"
-  value       = juju_application.nginx_ingress_integrator.name
-}
-
-output "nginx_ingress_integrator_requires" {
-  value = {}
-}
-
-output "nginx_ingress_integrator_provides" {
-  value = {
-    nginx_route = "nginx-route"
+    hardware_api = module.hardware_api
+    traefik_k8s  = juju_application.traefik_k8s
   }
 }

--- a/server/terraform/product/variables.tf
+++ b/server/terraform/product/variables.tf
@@ -25,3 +25,12 @@ variable "traefik_k8s" {
     revision = optional(number)
   })
 }
+
+variable "lego" {
+  type = object({
+    app_name = optional(string, "certificates")
+    channel  = optional(string, "latest/stable")
+    config   = optional(map(string), {})
+    revision = optional(number)
+  })
+}

--- a/server/terraform/product/variables.tf
+++ b/server/terraform/product/variables.tf
@@ -17,12 +17,11 @@ variable "hardware_api" {
   })
 }
 
-variable "nginx_ingress_integrator" {
+variable "traefik_k8s" {
   type = object({
     app_name = optional(string, "ingress")
     channel  = optional(string, "latest/stable")
     config   = optional(map(string), {})
     revision = optional(number)
-    units    = optional(number, 1)
   })
 }

--- a/server/terraform/product/variables.tf
+++ b/server/terraform/product/variables.tf
@@ -7,7 +7,7 @@ variable "model" {
 
 variable "hardware_api" {
   type = object({
-    app_name    = optional(string, "api")
+    app_name    = optional(string, "hwapi")
     channel     = optional(string, "latest/edge")
     config      = optional(map(string), {})
     constraints = optional(string, "arch=amd64")


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR updates the Terraform modules to use Traefik (and LEGO) instead of NGINX
- NGINX is deprecated, we are transitioning to using Traefik as the recommended ingress

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->

Untracked

## Testing

<!-- Describe the tests you ran to verify your changes. -->

- TODO: test on staging

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [ ] I have added necessary tests.
- [X] I have added or updated any relevant documentation (if needed).
- [ ] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
