### PR TITLE
chore(client): bump client version to v0.11.1

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hwlib"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "rlib"]
 [[bin]]
 name = "hwctl"
 path = "bin/hwctl.rs"
-features = ["cli"]
+required-features = ["cli"]
 
 [dependencies]
 anyhow = "~1.0.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hwlib"
 description = "Tool for checking Ubuntu hardware certification status"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = [
     "Canonical Hardware Certification <canonical-hw-cert@lists.launchpad.net>",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR bumps the client version to v0.11.1 since we've updated a lot of the dependencies since v0.11.0

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->


## Testing

<!-- Describe the tests you ran to verify your changes. -->

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [X] I have added necessary tests.
- [X] I have added or updated any relevant documentation (if needed).
- [X] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
