### PR TITLE
hwclt: Add cache for requests

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,10 +68,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
@@ -79,6 +100,19 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -196,6 +230,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +285,7 @@ name = "hwlib"
 version = "0.11.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "minreq",
  "os-release",
@@ -236,6 +295,30 @@ dependencies = [
  "serde_json",
  "simple_test_case",
  "smbios-lib",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -259,6 +342,17 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -328,6 +422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +493,12 @@ checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -508,6 +617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smbios-lib"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,10 +806,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -159,6 +159,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -187,10 +196,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "educe"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "errno"
@@ -295,6 +352,7 @@ dependencies = [
  "serde_json",
  "simple_test_case",
  "smbios-lib",
+ "test-temp-dir",
 ]
 
 [[package]]
@@ -422,6 +480,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +541,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -573,7 +650,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -585,7 +662,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -602,6 +679,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -655,6 +741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,7 +773,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -711,7 +803,7 @@ checksum = "6909e2382b73068b0172c9c28726b6fb9efeef51742ecfd05b9260c62c42bb8e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -744,6 +836,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -773,16 +876,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-temp-dir"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ad393ac6854caad65a989d8c70649d5d089cee7b7571bbcd8769c3b3b972d0"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "educe",
+ "tempfile",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -837,7 +964,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -871,7 +998,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -882,7 +1009,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,6 +24,7 @@ required-features = ["cli"]
 
 [dependencies]
 anyhow = "~1.0.0"
+chrono = "0.4.45"
 clap = { version = "4.5.41", features = ["derive", "env"], optional = true }
 minreq = { version = "3.0.0", features = [
     "native-tls",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -35,11 +35,11 @@ pyo3 = { version = "0.29.0", features = ["extension-module"], optional = true }
 serde = { version = "~1.0.0", features = ["derive"] }
 serde_json = "~1.0.0"
 smbios-lib = "0.9.0"
-test-temp-dir = "0.7.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 simple_test_case = "1.2.0"
+test-temp-dir = "0.7.0"
 
 [features]
 cli = ["clap"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -35,6 +35,7 @@ pyo3 = { version = "0.29.0", features = ["extension-module"], optional = true }
 serde = { version = "~1.0.0", features = ["derive"] }
 serde_json = "~1.0.0"
 smbios-lib = "0.9.0"
+test-temp-dir = "0.7.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/client/bin/hwctl.rs
+++ b/client/bin/hwctl.rs
@@ -63,7 +63,7 @@ fn run(server_url: String) -> Result<()> {
 
     let response = check_certification_status(
         server_url,
-        hwlib::CheckCertificationMode::Normal,
+        hwlib::CheckCertificationMode::Forced,
         &current_hardware,
         None,
     )
@@ -73,5 +73,13 @@ fn run(server_url: String) -> Result<()> {
         serde_json::to_string_pretty(&response).context("cannot serialize response as JSON")?;
     println!("{response_json}");
 
-    Ok(())
+    let (staled, stale_reason) = response.is_staled();
+
+    if staled {
+        return Err(anyhow::anyhow!(
+            stale_reason.unwrap_or("unknown reason".to_string())
+        ));
+    } else {
+        return Ok(());
+    }
 }

--- a/client/bin/hwctl.rs
+++ b/client/bin/hwctl.rs
@@ -21,8 +21,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::process::ExitCode;
 
+use hwlib::check_certification_status;
 use hwlib::models::request_validators::{CertificationStatusRequest, Paths};
-use hwlib::send_certification_status_request;
 
 /// CLI tool to check hardware certification status.
 ///
@@ -58,10 +58,16 @@ fn main() -> ExitCode {
 }
 
 fn run(server_url: String) -> Result<()> {
-    let cert_status_request =
+    let current_hardware =
         CertificationStatusRequest::new(Paths::default()).context("cannot collect system data")?;
-    let response = send_certification_status_request(server_url, &cert_status_request)
-        .context("cannot send certification status request")?;
+
+    let response = check_certification_status(
+        server_url,
+        hwlib::CheckCertificationMode::Normal,
+        &current_hardware,
+    )
+    .context("Failed")?;
+
     let response_json =
         serde_json::to_string_pretty(&response).context("cannot serialize response as JSON")?;
     println!("{response_json}");

--- a/client/bin/hwctl.rs
+++ b/client/bin/hwctl.rs
@@ -65,6 +65,7 @@ fn run(server_url: String) -> Result<()> {
         server_url,
         hwlib::CheckCertificationMode::Normal,
         &current_hardware,
+        None,
     )
     .context("Failed")?;
 

--- a/client/bin/hwctl.rs
+++ b/client/bin/hwctl.rs
@@ -63,7 +63,7 @@ fn run(server_url: String) -> Result<()> {
 
     let response = check_certification_status(
         server_url,
-        hwlib::CheckCertificationMode::Forced,
+        hwlib::CheckCertificationSource::Server,
         &current_hardware,
         None,
     );

--- a/client/bin/hwctl.rs
+++ b/client/bin/hwctl.rs
@@ -66,8 +66,7 @@ fn run(server_url: String) -> Result<()> {
         hwlib::CheckCertificationMode::Forced,
         &current_hardware,
         None,
-    )
-    .context("Failed")?;
+    );
 
     let response_json =
         serde_json::to_string_pretty(&response).context("cannot serialize response as JSON")?;

--- a/client/bin/hwctl.rs
+++ b/client/bin/hwctl.rs
@@ -73,7 +73,7 @@ fn run(server_url: String) -> Result<()> {
         serde_json::to_string_pretty(&response).context("cannot serialize response as JSON")?;
     println!("{response_json}");
 
-    let (staled, stale_reason) = response.is_staled();
+    let (staled, stale_reason) = response.stale_status();
 
     if staled {
         return Err(anyhow::anyhow!(

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -64,7 +64,7 @@ pub struct HWCache {
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct HWCacheData {
     certification_status: CertificationStatus,
-    certification_status_url: Option<String>,
+    certification_certified_url: Option<String>,
     stale: StaleStatus,
     stale_reason: Option<String>,
     last_attempt_at: Option<String>,
@@ -73,6 +73,7 @@ struct HWCacheData {
     hardware_data: Option<CertificationStatusRequest>,
     remote_access_enabled: bool,
     server: Option<String>,
+    available_releases: Vec<models::software::OS>,
 }
 
 impl HWCache {
@@ -167,12 +168,13 @@ impl HWCache {
     pub fn end_success_certification(
         &mut self,
         status: CertificationStatus,
-        status_url: Option<String>,
+        certified_url: Option<String>,
+        available_releases: Vec<models::software::OS>,
     ) {
         self.data.certification_status = status;
         let now = self.get_now();
         self.data.checked_at = Some(now.to_rfc3339());
-        self.data.certification_status_url = status_url;
+        self.data.certification_certified_url = certified_url;
         match self.data.certification_status {
             CertificationStatus::Certified => {
                 self.data.expires_at = Some(
@@ -194,6 +196,7 @@ impl HWCache {
         self.data.stale = StaleStatus::Valid;
         self.data.stale_reason = None;
         self.data.hardware_data = self.current_hardware_data.take();
+        self.data.available_releases = available_releases;
         self.save();
     }
 
@@ -208,7 +211,7 @@ impl HWCache {
     ) {
         return (
             self.data.certification_status.clone(),
-            self.data.certification_status_url.clone(),
+            self.data.certification_certified_url.clone(),
             self.data.stale.clone(),
             self.data.stale_reason.clone(),
         );
@@ -257,6 +260,10 @@ impl HWCache {
 
     pub fn get_remote_access_enabled(&self) -> bool {
         return self.data.remote_access_enabled;
+    }
+
+    pub fn get_available_releases(&self) -> Vec<models::software::OS> {
+        return self.data.available_releases.clone();
     }
 }
 
@@ -362,11 +369,12 @@ mod tests {
         cache.end_success_certification(
             CertificationStatus::Certified,
             Some("https://example.com/certified".to_string()),
+            vec![],
         );
 
-        assert!(cache.data.certification_status_url.is_some());
+        assert!(cache.data.certification_certified_url.is_some());
         assert!(
-            cache.data.certification_status_url.as_ref().unwrap()
+            cache.data.certification_certified_url.as_ref().unwrap()
                 == "https://example.com/certified"
         );
 
@@ -397,11 +405,12 @@ mod tests {
         cache.end_success_certification(
             CertificationStatus::Certified,
             Some("https://example.com/certified".to_string()),
+            vec![],
         );
 
-        assert!(cache.data.certification_status_url.is_some());
+        assert!(cache.data.certification_certified_url.is_some());
         assert!(
-            cache.data.certification_status_url.as_ref().unwrap()
+            cache.data.certification_certified_url.as_ref().unwrap()
                 == "https://example.com/certified"
         );
 
@@ -420,29 +429,30 @@ mod tests {
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
 
-        let (status, status_url, stale_status, _) = cache.get_status();
+        let (status, certified_url, stale_status, _) = cache.get_status();
         assert_eq!(status, CertificationStatus::Unknown);
         assert_eq!(stale_status, StaleStatus::Valid);
-        assert!(status_url.is_none());
+        assert!(certified_url.is_none());
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
         cache.end_success_certification(
             CertificationStatus::Certified,
             Some("https://example.com/certified".to_string()),
+            vec![],
         );
 
-        let (status, status_url, stale_status, _) = cache.get_status();
+        let (status, certified_url, stale_status, _) = cache.get_status();
         assert_eq!(status, CertificationStatus::Certified);
-        assert_eq!(status_url.unwrap(), "https://example.com/certified");
+        assert_eq!(certified_url.unwrap(), "https://example.com/certified");
         assert_eq!(stale_status, StaleStatus::Valid);
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
         cache
             .end_failed_certification(StaleStatus::ConnectingError, "Connection error".to_string());
 
-        let (status, status_url, stale_status, stale_reason) = cache.get_status();
+        let (status, certified_url, stale_status, stale_reason) = cache.get_status();
         assert_eq!(status, CertificationStatus::Certified);
-        assert_eq!(status_url.unwrap(), "https://example.com/certified");
+        assert_eq!(certified_url.unwrap(), "https://example.com/certified");
         assert_eq!(stale_status, StaleStatus::ConnectingError);
         assert_eq!(stale_reason.unwrap(), "Connection error");
 
@@ -462,11 +472,12 @@ mod tests {
         cache.end_success_certification(
             CertificationStatus::Certified,
             Some("https://example.com/certified".to_string()),
+            vec![],
         );
 
-        assert!(cache.data.certification_status_url.is_some());
+        assert!(cache.data.certification_certified_url.is_some());
         assert!(
-            cache.data.certification_status_url.as_ref().unwrap()
+            cache.data.certification_certified_url.as_ref().unwrap()
                 == "https://example.com/certified"
         );
 
@@ -502,9 +513,9 @@ mod tests {
         assert!(cache.get_remote_access_enabled());
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
-        cache.end_success_certification(CertificationStatus::NotSeen, None);
+        cache.end_success_certification(CertificationStatus::NotSeen, None, vec![]);
 
-        assert!(cache.data.certification_status_url.is_none());
+        assert!(cache.data.certification_certified_url.is_none());
 
         let expires_at_not_seen = cache.data.expires_at.clone();
         assert!(expires_at_not_seen.is_some());

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -25,33 +25,23 @@ use serde::{Deserialize, Serialize};
 
 use models::request_validators::CertificationStatusRequest;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub enum CertificationStatus {
     Certified,
     NotSeen,
     CertifiedImageExists,
     RelatedCertifiedSystemExists,
+    #[default]
     Unknown,
 }
 
-impl Default for CertificationStatus {
-    fn default() -> Self {
-        CertificationStatus::Unknown
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub enum StaleStatus {
     Connecting,
     ConnectingError,
     ServerError,
+    #[default]
     Valid,
-}
-
-impl Default for StaleStatus {
-    fn default() -> Self {
-        StaleStatus::Valid
-    }
 }
 
 /// A cache for the hardware data and certification status.
@@ -78,15 +68,14 @@ struct HWCacheData {
 
 impl HWCache {
     fn get_cache_path(cache_folder: Option<&Path>) -> PathBuf {
-        let snap_data: &Path;
         // snap_data_env must be defined outside the if statement to avoid the compiler to complain
         // about the data being dropped too early.
         let snap_data_env = env::var("SNAP_DATA").unwrap_or_else(|_| ".".to_string());
-        if cache_folder.is_none() {
-            snap_data = Path::new(&snap_data_env);
+        let snap_data: &Path = if cache_folder.is_none() {
+            Path::new(&snap_data_env)
         } else {
-            snap_data = cache_folder.unwrap();
-        }
+            cache_folder.unwrap()
+        };
         let cache_path = Path::join(snap_data, crate::constants::CACHE_FILE_NAME);
         return cache_path;
     }
@@ -288,7 +277,7 @@ mod tests {
                 version: "".to_string(),
             },
             chassis: None,
-            model: model,
+            model,
             os: OS {
                 codename: "".to_string(),
                 distributor: "".to_string(),

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -213,8 +213,19 @@ impl HWCache {
         now > expires_at.unwrap()
     }
 
-    pub fn set_remote_access_enabled(&mut self, enabled: bool) {
-        self.data.remote_access_enabled = enabled;
+    pub fn set_remote_access_enabled(&mut self, new_state: bool) {
+        self.data.remote_access_enabled = new_state;
+        if !new_state {
+            // invalidate the cache if remote access is disabled, to
+            // ensure to force a new check if remote access is re-enabled.
+            self.data.stale = StaleStatus::Valid;
+            self.data.stale_reason = None;
+            self.data.certification_status = CertificationStatus::Unknown;
+            self.data.expires_at = None;
+            self.data.checked_at = None;
+            self.data.last_attempt_at = None;
+            self.data.hardware_data = None;
+        }
         self.save();
     }
 

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -305,7 +305,7 @@ mod tests {
         }
     }
 
-    fn set_snap_data_env_var() -> TestTempDir {
+    fn create_temporal_cache_folder() -> TestTempDir {
         // Ensures that each test runs in a separate temporary directory. Can't
         // just set SNAP_DATA to a new temp dir because the tests seem to run in
         // parallel, so the variable would be overwritten.
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_set_remote_access_enabled() {
-        let temp_dir = set_snap_data_env_var();
+        let temp_dir = create_temporal_cache_folder();
 
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         cache.set_remote_access_enabled(true);
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_cache_is_kept() {
-        let temp_dir = set_snap_data_env_var();
+        let temp_dir = create_temporal_cache_folder();
 
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_cache_is_invalidated() {
-        let temp_dir = set_snap_data_env_var();
+        let temp_dir = create_temporal_cache_folder();
 
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_cache_hardware_mismatch() {
-        let temp_dir = set_snap_data_env_var();
+        let temp_dir = create_temporal_cache_folder();
 
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_cache_state() {
-        let temp_dir = set_snap_data_env_var();
+        let temp_dir = create_temporal_cache_folder();
 
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_cache_expiration_date_for_certified() {
-        let temp_dir = set_snap_data_env_var();
+        let temp_dir = create_temporal_cache_folder();
 
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
@@ -494,7 +494,7 @@ mod tests {
 
     #[test]
     fn test_cache_expiration_date_for_not_seen() {
-        let temp_dir = set_snap_data_env_var();
+        let temp_dir = create_temporal_cache_folder();
 
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -408,4 +408,72 @@ mod tests {
 
         keep_temp_dir_alive(&temp_dir);
     }
+
+    #[test]
+    fn test_cache_expiration_date_for_certified() {
+        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+
+        let mut cache = HWCache::new(Some(temp_dir_path));
+        assert!(!cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+
+        cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
+        cache.end_success_certification(CertificationStatus::Certified);
+
+        let expires_at_certified = cache.data.expires_at.clone();
+        assert!(expires_at_certified.is_some());
+        let checked_at_certified = cache.data.checked_at.clone();
+        assert!(checked_at_certified.is_some());
+
+        let expires_date =
+            chrono::DateTime::parse_from_rfc3339(expires_at_certified.unwrap().as_str());
+        assert!(expires_date.is_ok());
+        let checked_date =
+            chrono::DateTime::parse_from_rfc3339(checked_at_certified.unwrap().as_str());
+        assert!(checked_date.is_ok());
+        assert!(
+            expires_date.unwrap()
+                == checked_date.unwrap()
+                    + chrono::Duration::seconds(
+                        crate::constants::CACHE_EXPIRATION_IF_CERTIFIED as i64
+                    )
+        );
+
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_cache_expiration_date_for_not_seen() {
+        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+
+        let mut cache = HWCache::new(Some(temp_dir_path));
+        assert!(!cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+
+        cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
+        cache.end_success_certification(CertificationStatus::NotSeen);
+
+        let expires_at_not_seen = cache.data.expires_at.clone();
+        assert!(expires_at_not_seen.is_some());
+        let checked_at_not_seen = cache.data.checked_at.clone();
+        assert!(checked_at_not_seen.is_some());
+
+        let expires_date =
+            chrono::DateTime::parse_from_rfc3339(expires_at_not_seen.unwrap().as_str());
+        assert!(expires_date.is_ok());
+        let checked_date =
+            chrono::DateTime::parse_from_rfc3339(checked_at_not_seen.unwrap().as_str());
+        assert!(checked_date.is_ok());
+        assert!(
+            expires_date.unwrap()
+                == checked_date.unwrap()
+                    + chrono::Duration::seconds(
+                        crate::constants::CACHE_EXPIRATION_IF_NOT_CERTIFIED as i64
+                    )
+        );
+
+        keep_temp_dir_alive(&temp_dir);
+    }
 }

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -64,6 +64,7 @@ pub struct HWCache {
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct HWCacheData {
     certification_status: CertificationStatus,
+    certification_status_url: Option<String>,
     stale: StaleStatus,
     stale_reason: Option<String>,
     last_attempt_at: Option<String>,
@@ -163,10 +164,15 @@ impl HWCache {
     /// and which is the new certification status of the system.
     ///
     /// status: The new certification status of the system.
-    pub fn end_success_certification(&mut self, status: CertificationStatus) {
+    pub fn end_success_certification(
+        &mut self,
+        status: CertificationStatus,
+        status_url: Option<String>,
+    ) {
         self.data.certification_status = status;
         let now = self.get_now();
         self.data.checked_at = Some(now.to_rfc3339());
+        self.data.certification_status_url = status_url;
         match self.data.certification_status {
             CertificationStatus::Certified => {
                 self.data.expires_at = Some(
@@ -192,9 +198,17 @@ impl HWCache {
     }
 
     /// Returns the current certification status, stale status, and stale reason (if any).
-    pub fn get_status(&self) -> (CertificationStatus, StaleStatus, Option<String>) {
-        return(
+    pub fn get_status(
+        &self,
+    ) -> (
+        CertificationStatus,
+        Option<String>,
+        StaleStatus,
+        Option<String>,
+    ) {
+        return (
             self.data.certification_status.clone(),
+            self.data.certification_status_url.clone(),
             self.data.stale.clone(),
             self.data.stale_reason.clone(),
         );
@@ -345,7 +359,16 @@ mod tests {
         assert!(cache.is_expired());
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
-        cache.end_success_certification(CertificationStatus::Certified);
+        cache.end_success_certification(
+            CertificationStatus::Certified,
+            Some("https://example.com/certified".to_string()),
+        );
+
+        assert!(cache.data.certification_status_url.is_some());
+        assert!(
+            cache.data.certification_status_url.as_ref().unwrap()
+                == "https://example.com/certified"
+        );
 
         assert!(!cache.is_expired());
         assert!(cache.get_remote_access_enabled());
@@ -371,7 +394,16 @@ mod tests {
         assert!(cache.get_remote_access_enabled());
 
         cache.begin_certification(None, &create_test_hardware_data("test_model1".to_string()));
-        cache.end_success_certification(CertificationStatus::Certified);
+        cache.end_success_certification(
+            CertificationStatus::Certified,
+            Some("https://example.com/certified".to_string()),
+        );
+
+        assert!(cache.data.certification_status_url.is_some());
+        assert!(
+            cache.data.certification_status_url.as_ref().unwrap()
+                == "https://example.com/certified"
+        );
 
         assert!(cache.compare_hardware_data(&create_test_hardware_data("test_model1".to_string())));
 
@@ -388,23 +420,29 @@ mod tests {
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
 
-        let (status, stale_status, _) = cache.get_status();
+        let (status, status_url, stale_status, _) = cache.get_status();
         assert_eq!(status, CertificationStatus::Unknown);
         assert_eq!(stale_status, StaleStatus::Valid);
+        assert!(status_url.is_none());
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
-        cache.end_success_certification(CertificationStatus::Certified);
+        cache.end_success_certification(
+            CertificationStatus::Certified,
+            Some("https://example.com/certified".to_string()),
+        );
 
-        let (status, stale_status, _) = cache.get_status();
+        let (status, status_url, stale_status, _) = cache.get_status();
         assert_eq!(status, CertificationStatus::Certified);
+        assert_eq!(status_url.unwrap(), "https://example.com/certified");
         assert_eq!(stale_status, StaleStatus::Valid);
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
         cache
             .end_failed_certification(StaleStatus::ConnectingError, "Connection error".to_string());
 
-        let (status, stale_status, stale_reason) = cache.get_status();
+        let (status, status_url, stale_status, stale_reason) = cache.get_status();
         assert_eq!(status, CertificationStatus::Certified);
+        assert_eq!(status_url.unwrap(), "https://example.com/certified");
         assert_eq!(stale_status, StaleStatus::ConnectingError);
         assert_eq!(stale_reason.unwrap(), "Connection error");
 
@@ -421,7 +459,16 @@ mod tests {
         assert!(cache.get_remote_access_enabled());
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
-        cache.end_success_certification(CertificationStatus::Certified);
+        cache.end_success_certification(
+            CertificationStatus::Certified,
+            Some("https://example.com/certified".to_string()),
+        );
+
+        assert!(cache.data.certification_status_url.is_some());
+        assert!(
+            cache.data.certification_status_url.as_ref().unwrap()
+                == "https://example.com/certified"
+        );
 
         let expires_at_certified = cache.data.expires_at.clone();
         assert!(expires_at_certified.is_some());
@@ -455,7 +502,9 @@ mod tests {
         assert!(cache.get_remote_access_enabled());
 
         cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
-        cache.end_success_certification(CertificationStatus::NotSeen);
+        cache.end_success_certification(CertificationStatus::NotSeen, None);
+
+        assert!(cache.data.certification_status_url.is_none());
 
         let expires_at_not_seen = cache.data.expires_at.clone();
         assert!(expires_at_not_seen.is_some());

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -17,16 +17,11 @@
  */
 
 use crate::models;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{env, fs::File};
 
 use chrono::DateTime;
 use serde::{Deserialize, Serialize};
-
-#[cfg(test)]
-use crate::models::software::OS;
-#[cfg(test)]
-use test_temp_dir::{test_temp_dir, TestTempDir};
 
 use models::request_validators::CertificationStatusRequest;
 
@@ -63,7 +58,7 @@ impl Default for StaleStatus {
 pub struct HWCache {
     data: HWCacheData,
     current_hardware_data: Option<CertificationStatusRequest>,
-    cache_path: String,
+    cache_path: PathBuf,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
@@ -80,22 +75,25 @@ struct HWCacheData {
 }
 
 impl HWCache {
-    fn get_cache_path(cache_folder: Option<String>) -> String {
-        let snap_data: String;
+    fn get_cache_path(cache_folder: Option<&Path>) -> PathBuf {
+        let snap_data: &Path;
+        // snap_data_env must be defined outside the if statement to avoid the compiler to complain
+        // about the data being dropped too early.
+        let snap_data_env = env::var("SNAP_DATA").unwrap_or_else(|_| ".".to_string());
         if cache_folder.is_none() {
-            snap_data = env::var("SNAP_DATA").unwrap_or_else(|_| ".".to_string());
+            snap_data = Path::new(&snap_data_env);
         } else {
             snap_data = cache_folder.unwrap();
         }
-        let cache_path = Path::join(Path::new(&snap_data), crate::constants::CACHE_PATH);
-        cache_path.to_str().unwrap().to_string()
+        let cache_path = Path::join(snap_data, crate::constants::CACHE_FILE_NAME);
+        return cache_path;
     }
 
     fn get_now(&self) -> DateTime<chrono::Utc> {
-        chrono::Utc::now()
+        return chrono::Utc::now();
     }
 
-    pub fn new(cache_folder: Option<String>) -> Self {
+    pub fn new(cache_folder: Option<&Path>) -> Self {
         let mut built_cache = HWCache {
             data: HWCacheData {
                 ..Default::default()
@@ -104,7 +102,7 @@ impl HWCache {
             cache_path: HWCache::get_cache_path(cache_folder),
         };
 
-        if !Path::new(&built_cache.cache_path).exists() {
+        if !built_cache.cache_path.exists() {
             return built_cache;
         }
         let config = File::open(built_cache.cache_path.clone());
@@ -195,16 +193,16 @@ impl HWCache {
 
     /// Returns the current certification status, stale status, and stale reason (if any).
     pub fn get_status(&self) -> (CertificationStatus, StaleStatus, Option<String>) {
-        (
+        return(
             self.data.certification_status.clone(),
             self.data.stale.clone(),
             self.data.stale_reason.clone(),
-        )
+        );
     }
 
     /// Compares the given hardware data with the cached hardware data.
     /// Returns true if they are the same, false otherwise.
-    pub fn compare_hardware_data(&mut self, hardware_data: &CertificationStatusRequest) -> bool {
+    pub fn compare_hardware_data(&self, hardware_data: &CertificationStatusRequest) -> bool {
         if self.data.hardware_data.is_some()
             && self.data.hardware_data.as_ref().unwrap() == hardware_data
         {
@@ -224,7 +222,7 @@ impl HWCache {
             return true;
         }
         let now = self.get_now();
-        now > expires_at.unwrap()
+        return now > expires_at.unwrap();
     }
 
     pub fn set_remote_access_enabled(&mut self, new_state: bool) {
@@ -244,17 +242,18 @@ impl HWCache {
     }
 
     pub fn get_remote_access_enabled(&self) -> bool {
-        self.data.remote_access_enabled
+        return self.data.remote_access_enabled;
     }
 }
 
 #[cfg(test)]
 mod tests {
-
+    use crate::models::software::OS;
     use crate::models::{
         devices::{Board, Processor},
         software::KernelPackage,
     };
+    use test_temp_dir::{test_temp_dir, TestTempDir};
 
     use super::*;
 
@@ -292,13 +291,12 @@ mod tests {
         }
     }
 
-    fn set_snap_data_env_var() -> (TestTempDir, String) {
+    fn set_snap_data_env_var() -> TestTempDir {
         // Ensures that each test runs in a separate temporary directory. Can't
         // just set SNAP_DATA to a new temp dir because the tests seem to run in
         // parallel, so the variable would be overwritten.
         let temp_dir = test_temp_dir!();
-        let temp_dir_path = temp_dir.as_path_untracked().to_str().unwrap().to_string();
-        return (temp_dir, temp_dir_path);
+        return temp_dir;
     }
 
     fn keep_temp_dir_alive(_temp_dir: &TestTempDir) {
@@ -307,9 +305,9 @@ mod tests {
 
     #[test]
     fn test_set_remote_access_enabled() {
-        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+        let temp_dir = set_snap_data_env_var();
 
-        let mut cache = HWCache::new(Some(temp_dir_path));
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
         cache.set_remote_access_enabled(false);
@@ -322,14 +320,14 @@ mod tests {
 
     #[test]
     fn test_cache_is_kept() {
-        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+        let temp_dir = set_snap_data_env_var();
 
-        let mut cache = HWCache::new(Some(temp_dir_path.clone()));
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
 
-        let cache2 = HWCache::new(Some(temp_dir_path));
+        let cache2 = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(cache2.get_remote_access_enabled());
 
         keep_temp_dir_alive(&temp_dir);
@@ -337,9 +335,9 @@ mod tests {
 
     #[test]
     fn test_cache_is_invalidated() {
-        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+        let temp_dir = set_snap_data_env_var();
 
-        let mut cache = HWCache::new(Some(temp_dir_path));
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
@@ -365,9 +363,9 @@ mod tests {
 
     #[test]
     fn test_cache_hardware_mismatch() {
-        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+        let temp_dir = set_snap_data_env_var();
 
-        let mut cache = HWCache::new(Some(temp_dir_path));
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
@@ -383,9 +381,9 @@ mod tests {
 
     #[test]
     fn test_cache_state() {
-        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+        let temp_dir = set_snap_data_env_var();
 
-        let mut cache = HWCache::new(Some(temp_dir_path));
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
@@ -415,9 +413,9 @@ mod tests {
 
     #[test]
     fn test_cache_expiration_date_for_certified() {
-        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+        let temp_dir = set_snap_data_env_var();
 
-        let mut cache = HWCache::new(Some(temp_dir_path));
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());
@@ -449,9 +447,9 @@ mod tests {
 
     #[test]
     fn test_cache_expiration_date_for_not_seen() {
-        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+        let temp_dir = set_snap_data_env_var();
 
-        let mut cache = HWCache::new(Some(temp_dir_path));
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         assert!(!cache.get_remote_access_enabled());
         cache.set_remote_access_enabled(true);
         assert!(cache.get_remote_access_enabled());

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -23,9 +23,14 @@ use std::{env, fs::File};
 use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+use crate::models::software::OS;
+#[cfg(test)]
+use test_temp_dir::{test_temp_dir, TestTempDir};
+
 use models::request_validators::CertificationStatusRequest;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum CertificationStatus {
     Certified,
     NotSeen,
@@ -63,8 +68,13 @@ struct HWCacheData {
 }
 
 impl HWCache {
-    fn get_cache_path() -> String {
-        let snap_data = env::var("SNAP_DATA").unwrap_or_else(|_| ".".to_string());
+    fn get_cache_path(cache_folder: Option<String>) -> String {
+        let snap_data: String;
+        if cache_folder.is_none() {
+            snap_data = env::var("SNAP_DATA").unwrap_or_else(|_| ".".to_string());
+        } else {
+            snap_data = cache_folder.unwrap();
+        }
         let cache_path = Path::join(Path::new(&snap_data), crate::constants::CACHE_PATH);
         cache_path.to_str().unwrap().to_string()
     }
@@ -73,7 +83,7 @@ impl HWCache {
         chrono::Utc::now()
     }
 
-    pub fn new() -> Self {
+    pub fn new(cache_folder: Option<String>) -> Self {
         let mut built_cache = HWCache {
             data: HWCacheData {
                 certification_status: CertificationStatus::Unknown,
@@ -83,11 +93,11 @@ impl HWCache {
                 checked_at: None,
                 expires_at: None,
                 hardware_data: None,
-                remote_access_enabled: true,
+                remote_access_enabled: false,
                 server: None,
             },
             current_hardware_data: None,
-            cache_path: HWCache::get_cache_path(),
+            cache_path: HWCache::get_cache_path(cache_folder),
         };
 
         if !Path::new(&built_cache.cache_path).exists() {
@@ -231,5 +241,171 @@ impl HWCache {
 
     pub fn get_remote_access_enabled(&self) -> bool {
         self.data.remote_access_enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::models::{
+        devices::{Board, Processor},
+        software::KernelPackage,
+    };
+
+    use super::*;
+
+    fn create_test_hardware_data(model: String) -> CertificationStatusRequest {
+        CertificationStatusRequest {
+            architecture: "x86_64".to_string(),
+            bios: None,
+            board: Board {
+                manufacturer: "".to_string(),
+                product_name: "".to_string(),
+                version: "".to_string(),
+            },
+            chassis: None,
+            model: model,
+            os: OS {
+                codename: "".to_string(),
+                distributor: "".to_string(),
+                version: "".to_string(),
+                kernel: KernelPackage {
+                    name: None,
+                    version: "".to_string(),
+                    signature: None,
+                    loaded_modules: vec![],
+                },
+            },
+            pci_peripherals: vec![],
+            processor: Processor {
+                identifier: None,
+                frequency: 0,
+                version: "".to_string(),
+                manufacturer: "".to_string(),
+            },
+            usb_peripherals: vec![],
+            vendor: "".to_string(),
+        }
+    }
+
+    fn set_snap_data_env_var() -> (TestTempDir, String) {
+        // Ensures that each test runs in a separate temporary directory. Can't
+        // just set SNAP_DATA to a new temp dir because the tests seem to run in
+        // parallel, so the variable would be overwritten.
+        let temp_dir = test_temp_dir!();
+        let temp_dir_path = temp_dir.as_path_untracked().to_str().unwrap().to_string();
+        return (temp_dir, temp_dir_path);
+    }
+
+    fn keep_temp_dir_alive(_temp_dir: &TestTempDir) {
+        // Keep the temp dir alive until the end of the test
+    }
+
+    #[test]
+    fn test_set_remote_access_enabled() {
+        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+
+        let mut cache = HWCache::new(Some(temp_dir_path));
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(false);
+        assert!(!cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_cache_is_kept() {
+        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+
+        let mut cache = HWCache::new(Some(temp_dir_path.clone()));
+        assert!(!cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+
+        let cache2 = HWCache::new(Some(temp_dir_path));
+        assert!(cache2.get_remote_access_enabled());
+
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_cache_is_invalidated() {
+        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+
+        let mut cache = HWCache::new(Some(temp_dir_path));
+        assert!(!cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+
+        assert!(cache.is_expired());
+
+        cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
+        cache.end_success_certification(CertificationStatus::Certified);
+
+        assert!(!cache.is_expired());
+        assert!(cache.get_remote_access_enabled());
+
+        cache.set_remote_access_enabled(false);
+        assert!(!cache.get_remote_access_enabled());
+        assert!(cache.is_expired());
+
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+        assert!(cache.is_expired());
+
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_cache_hardware_mismatch() {
+        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+
+        let mut cache = HWCache::new(Some(temp_dir_path));
+        assert!(!cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+
+        cache.begin_certification(None, &create_test_hardware_data("test_model1".to_string()));
+        cache.end_success_certification(CertificationStatus::Certified);
+
+        assert!(cache.compare_hardware_data(&create_test_hardware_data("test_model1".to_string())));
+
+        assert!(!cache.compare_hardware_data(&create_test_hardware_data("test_model2".to_string())));
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_cache_state() {
+        let (temp_dir, temp_dir_path) = set_snap_data_env_var();
+
+        let mut cache = HWCache::new(Some(temp_dir_path));
+        assert!(!cache.get_remote_access_enabled());
+        cache.set_remote_access_enabled(true);
+        assert!(cache.get_remote_access_enabled());
+
+        let (status, stale_status, _) = cache.get_status();
+        assert_eq!(status, CertificationStatus::Unknown);
+        assert_eq!(stale_status, StaleStatus::Valid);
+
+        cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
+        cache.end_success_certification(CertificationStatus::Certified);
+
+        let (status, stale_status, _) = cache.get_status();
+        assert_eq!(status, CertificationStatus::Certified);
+        assert_eq!(stale_status, StaleStatus::Valid);
+
+        cache.begin_certification(None, &create_test_hardware_data("test_model".to_string()));
+        cache
+            .end_failed_certification(StaleStatus::ConnectingError, "Connection error".to_string());
+
+        let (status, stale_status, stale_reason) = cache.get_status();
+        assert_eq!(status, CertificationStatus::Certified);
+        assert_eq!(stale_status, StaleStatus::ConnectingError);
+        assert_eq!(stale_reason.unwrap(), "Connection error");
+
+        keep_temp_dir_alive(&temp_dir);
     }
 }

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -1,0 +1,224 @@
+/* Copyright 2026 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 3, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Written by:
+ *        Sergio Costas Rodríguez <sergio.costas@canonical.com>
+ */
+
+use crate::models;
+use std::path::Path;
+use std::{env, fs::File};
+
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
+
+use models::request_validators::CertificationStatusRequest;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum CertificationStatus {
+    Certified,
+    NotSeen,
+    CertifiedImageExists,
+    RelatedCertifiedSystemExists,
+    Unknown,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum StaleStatus {
+    Connecting,
+    ConnectingError,
+    ServerError,
+    Valid,
+}
+
+/// A cache for the hardware data and certification status.
+pub struct HWCache {
+    data: HWCacheData,
+    current_hardware_data: Option<CertificationStatusRequest>,
+    cache_path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct HWCacheData {
+    certification_status: CertificationStatus,
+    stale: StaleStatus,
+    stale_reason: Option<String>,
+    last_attempt_at: Option<String>,
+    checked_at: Option<String>,
+    expires_at: Option<String>,
+    hardware_data: Option<CertificationStatusRequest>,
+    remote_access_enabled: bool,
+    server: Option<String>,
+}
+
+impl HWCache {
+    fn get_cache_path() -> String {
+        let snap_data = env::var("SNAP_DATA").unwrap_or_else(|_| ".".to_string());
+        let cache_path = Path::join(Path::new(&snap_data), crate::constants::CACHE_PATH);
+        cache_path.to_str().unwrap().to_string()
+    }
+
+    fn get_now(&self) -> DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
+
+    pub fn new() -> Self {
+        let mut built_cache = HWCache {
+            data: HWCacheData {
+                certification_status: CertificationStatus::Unknown,
+                stale: StaleStatus::Valid,
+                stale_reason: None,
+                last_attempt_at: None,
+                checked_at: None,
+                expires_at: None,
+                hardware_data: None,
+                remote_access_enabled: true,
+                server: None,
+            },
+            current_hardware_data: None,
+            cache_path: HWCache::get_cache_path(),
+        };
+
+        if !Path::new(&built_cache.cache_path).exists() {
+            return built_cache;
+        }
+        let config = File::open(built_cache.cache_path.clone());
+        if config.is_err() {
+            return built_cache;
+        }
+        let cache: Result<HWCacheData, serde_json::Error> =
+            serde_json::from_reader(config.unwrap());
+        if cache.is_err() {
+            return built_cache;
+        }
+        built_cache.data = cache.unwrap();
+        return built_cache;
+    }
+
+    fn save(&self) {
+        let config = File::create(self.cache_path.clone());
+        if config.is_err() {
+            return;
+        }
+        let _ = serde_json::to_writer_pretty(config.unwrap(), &self.data);
+    }
+
+    /// Specifies that a new certification check against a remote server is being started.
+    ///
+    /// server: The URL of the server to which the certification request will be sent.
+    /// hardware_data: The hardware data that will be sent in the certification request.
+    pub fn begin_certification(
+        &mut self,
+        server: Option<String>,
+        hardware_data: &CertificationStatusRequest,
+    ) {
+        self.data.stale = StaleStatus::Connecting;
+        self.data.stale_reason = None;
+        self.data.last_attempt_at = Some(self.get_now().to_rfc3339());
+        self.data.server = server;
+        self.current_hardware_data = Some(hardware_data.clone());
+        self.save();
+    }
+
+    /// Specifies that the certification check against a remote server has failed.
+    ///
+    /// status: The new stale status of the failed certification check, specifying
+    /// whether it was a connection error or a server error.
+    /// reason: The reason for the failure if it was a server error.
+    pub fn end_failed_certification(&mut self, status: StaleStatus, reason: String) {
+        match status {
+            StaleStatus::ConnectingError | StaleStatus::ServerError => {}
+            _ => return,
+        }
+        self.data.stale = status;
+        self.data.stale_reason = Some(reason);
+        self.current_hardware_data = None;
+        self.save();
+    }
+
+    /// Notifies the cache that the certification check against a remote server has succeeded,
+    /// and which is the new certification status of the system.
+    ///
+    /// status: The new certification status of the system.
+    pub fn end_success_certification(&mut self, status: CertificationStatus) {
+        self.data.certification_status = status;
+        let now = self.get_now();
+        self.data.checked_at = Some(now.to_rfc3339());
+        match self.data.certification_status {
+            CertificationStatus::Certified => {
+                self.data.expires_at = Some(
+                    (now + chrono::Duration::seconds(
+                        crate::constants::CACHE_EXPIRATION_IF_CERTIFIED as i64,
+                    ))
+                    .to_rfc3339(),
+                );
+            }
+            _ => {
+                self.data.expires_at = Some(
+                    (now + chrono::Duration::seconds(
+                        crate::constants::CACHE_EXPIRATION_IF_NOT_CERTIFIED as i64,
+                    ))
+                    .to_rfc3339(),
+                );
+            }
+        }
+        self.data.stale = StaleStatus::Valid;
+        self.data.stale_reason = None;
+        self.data.hardware_data = self.current_hardware_data.take();
+        self.save();
+    }
+
+    /// Returns the current certification status, stale status, and stale reason (if any).
+    pub fn get_status(&self) -> (CertificationStatus, StaleStatus, Option<String>) {
+        (
+            self.data.certification_status.clone(),
+            self.data.stale.clone(),
+            self.data.stale_reason.clone(),
+        )
+    }
+
+    /// Compares the given hardware data with the cached hardware data.
+    /// Returns true if they are the same, false otherwise.
+    pub fn compare_hardware_data(&mut self, hardware_data: &CertificationStatusRequest) -> bool {
+        if self.data.hardware_data.is_some()
+            && self.data.hardware_data.as_ref().unwrap() == hardware_data
+        {
+            return true;
+        }
+        return false;
+    }
+
+    /// Returns true if the cache has expired, false otherwise.
+    pub fn is_expired(&self) -> bool {
+        if self.data.expires_at.is_none() {
+            return true;
+        }
+        let expires_at =
+            chrono::DateTime::parse_from_rfc3339(self.data.expires_at.as_ref().unwrap());
+        if expires_at.is_err() {
+            return true;
+        }
+        let now = self.get_now();
+        now > expires_at.unwrap()
+    }
+
+    pub fn set_remote_access_enabled(&mut self, enabled: bool) {
+        self.data.remote_access_enabled = enabled;
+        self.save();
+    }
+
+    pub fn get_remote_access_enabled(&self) -> bool {
+        self.data.remote_access_enabled
+    }
+}

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -39,12 +39,24 @@ pub enum CertificationStatus {
     Unknown,
 }
 
+impl Default for CertificationStatus {
+    fn default() -> Self {
+        CertificationStatus::Unknown
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum StaleStatus {
     Connecting,
     ConnectingError,
     ServerError,
     Valid,
+}
+
+impl Default for StaleStatus {
+    fn default() -> Self {
+        StaleStatus::Valid
+    }
 }
 
 /// A cache for the hardware data and certification status.
@@ -54,7 +66,7 @@ pub struct HWCache {
     cache_path: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 struct HWCacheData {
     certification_status: CertificationStatus,
     stale: StaleStatus,
@@ -86,15 +98,7 @@ impl HWCache {
     pub fn new(cache_folder: Option<String>) -> Self {
         let mut built_cache = HWCache {
             data: HWCacheData {
-                certification_status: CertificationStatus::Unknown,
-                stale: StaleStatus::Valid,
-                stale_reason: None,
-                last_attempt_at: None,
-                checked_at: None,
-                expires_at: None,
-                hardware_data: None,
-                remote_access_enabled: false,
-                server: None,
+                ..Default::default()
             },
             current_hardware_data: None,
             cache_path: HWCache::get_cache_path(cache_folder),
@@ -147,9 +151,9 @@ impl HWCache {
     /// whether it was a connection error or a server error.
     /// reason: The reason for the failure if it was a server error.
     pub fn end_failed_certification(&mut self, status: StaleStatus, reason: String) {
-        match status {
-            StaleStatus::ConnectingError | StaleStatus::ServerError => {}
-            _ => return,
+        // Only update the stale status if it is a connection error or a server error.
+        if status != StaleStatus::ConnectingError && status != StaleStatus::ServerError {
+            return;
         }
         self.data.stale = status;
         self.data.stale_reason = Some(reason);

--- a/client/src/constants.rs
+++ b/client/src/constants.rs
@@ -30,4 +30,4 @@ pub const LSMOD: &str = "/usr/bin/lsmod";
 
 pub const CACHE_EXPIRATION_IF_CERTIFIED: u64 = 60 * 60 * 24 * 30; // 30  days
 pub const CACHE_EXPIRATION_IF_NOT_CERTIFIED: u64 = 60 * 60 * 24; // 1 day
-pub const CACHE_PATH: &str = "hw_cache.json";
+pub const CACHE_FILE_NAME: &str = "hw_cache.json";

--- a/client/src/constants.rs
+++ b/client/src/constants.rs
@@ -27,3 +27,7 @@ pub const PROC_VERSION_FILE_PATH: &str = "/proc/version";
 pub const OS_RELEASE_FILE_PATH: &str = env!("OS_RELEASE_FILE_PATH");
 
 pub const LSMOD: &str = "/usr/bin/lsmod";
+
+pub const CACHE_EXPIRATION_IF_CERTIFIED: u64 = 60 * 60 * 24 * 30; // 30  days
+pub const CACHE_EXPIRATION_IF_NOT_CERTIFIED: u64 = 60 * 60 * 24; // 1 day
+pub const CACHE_PATH: &str = "hw_cache.json";

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -41,10 +41,10 @@ pub use cache::{CertificationStatus, HWCache, StaleStatus};
 use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq)]
-pub enum CheckCertificationMode {
-    Normal,
-    Cached,
-    Forced,
+pub enum CheckCertificationSource {
+    Auto,
+    Cache,
+    Server,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -120,7 +120,7 @@ fn send_request(
 
 pub fn check_certification_status(
     url: String,
-    mode: CheckCertificationMode,
+    mode: CheckCertificationSource,
     hardware_info: &CertificationStatusRequest,
     cache_opt: Option<&mut HWCache>,
 ) -> PublicCertificationStatus {
@@ -132,23 +132,23 @@ pub fn check_certification_status(
     let cache_answer =
         |cache: &HWCache| create_answer(cache, CertificationSource::Cache, hardware_info);
 
-    if mode == CheckCertificationMode::Cached {
+    if mode == CheckCertificationSource::Cache {
         return cache_answer(cache);
     }
 
     let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
     if !cache.get_remote_access_enabled()
         && hardware_mismatch
-        && mode != CheckCertificationMode::Forced
+        && mode != CheckCertificationSource::Server
     {
         return cache_answer(cache);
     }
 
-    if !cache.is_expired() && mode != CheckCertificationMode::Forced {
+    if !cache.is_expired() && mode != CheckCertificationSource::Server {
         return cache_answer(cache);
     }
 
-    if !cache.get_remote_access_enabled() && mode != CheckCertificationMode::Forced {
+    if !cache.get_remote_access_enabled() && mode != CheckCertificationSource::Server {
         return cache_answer(cache);
     }
 
@@ -333,7 +333,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let _ = check_certification_status(
             "connectionerror_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -351,7 +351,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "certifiedimageexists_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -372,7 +372,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -393,7 +393,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "relatedcertifiedsystemexists_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -417,7 +417,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "not_seen_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -437,7 +437,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -455,7 +455,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -467,7 +467,7 @@ mod tests {
 
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -487,7 +487,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -499,7 +499,7 @@ mod tests {
 
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Forced,
+            CheckCertificationSource::Server,
             &hardware_info,
             Some(&mut cache),
         );
@@ -521,7 +521,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -534,7 +534,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("arm64".to_string());
         let data = check_certification_status(
             "certified_arm64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -547,7 +547,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("arm64".to_string());
         let data = check_certification_status(
             "certified_arm64".to_string(),
-            CheckCertificationMode::Forced,
+            CheckCertificationSource::Server,
             &hardware_info,
             Some(&mut cache),
         );
@@ -569,7 +569,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let data = check_certification_status(
             "certified_x86_64".to_string(),
-            CheckCertificationMode::Normal,
+            CheckCertificationSource::Auto,
             &hardware_info,
             Some(&mut cache),
         );
@@ -582,7 +582,7 @@ mod tests {
         let hardware_info = create_test_hardware_data("arm64".to_string());
         let data = check_certification_status(
             "certified_arm64".to_string(),
-            CheckCertificationMode::Cached,
+            CheckCertificationSource::Cache,
             &hardware_info,
             Some(&mut cache),
         );

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -234,8 +234,8 @@ fn send_request(
         });
     }
 
-    if only_url.starts_with("related_certified_system_exists_") {
-        let arch = only_url.split("_").nth(4).unwrap();
+    if only_url.starts_with("relatedcertifiedsystemexists_") {
+        let arch = only_url.split("_").nth(1).unwrap();
         return Result::Ok(CertificationStatusResponse::RelatedCertifiedSystemExists {
             certified_url: format!("https://certification.ubuntu.com/hardware/{}", arch),
             architecture: arch.to_string(),
@@ -253,8 +253,8 @@ fn send_request(
         });
     }
 
-    if only_url.starts_with("certified_image_exists_") {
-        let arch = only_url.split("_").nth(3).unwrap();
+    if only_url.starts_with("certifiedimageexists_") {
+        let arch = only_url.split("_").nth(1).unwrap();
         return Result::Ok(CertificationStatusResponse::CertifiedImageExists {
             certified_url: format!("https://certification.ubuntu.com/hardware/{}", arch),
             architecture: arch.to_string(),
@@ -328,7 +328,7 @@ mod tests {
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let result = check_certification_status(
-            "certified_image_exists_x86_64".to_string(),
+            "certifiedimageexists_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
@@ -374,7 +374,7 @@ mod tests {
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
         let result = check_certification_status(
-            "related_certified_system_exists_x86_64".to_string(),
+            "relatedcertifiedsystemexists_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -47,7 +47,7 @@ pub enum CheckCertificationMode {
     Forced,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, PartialEq)]
 pub enum CertificationSource {
     Cache,
     Server,
@@ -72,12 +72,11 @@ fn create_answer(
 ) -> PublicCertificationStatus {
     let (certification_status, certification_status_url, stale_status, stale_reason) =
         cache.get_status();
-    let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
     return PublicCertificationStatus {
         status: certification_status,
         status_url: certification_status_url,
         valid_cache: !cache.is_expired(),
-        hardware_mismatch: hardware_mismatch,
+        hardware_mismatch: !cache.compare_hardware_data(hardware_info),
         stale: stale_status != StaleStatus::Valid,
         stale_reason: stale_reason,
         source: source,
@@ -85,13 +84,34 @@ fn create_answer(
     };
 }
 
+#[cfg(not(test))]
+fn send_request(
+    server_url: String,
+    hardware_info: &CertificationStatusRequest,
+) -> Result<CertificationStatusResponse> {
+    let response = minreq::post(&server_url).with_json(hardware_info)?.send();
+    if response.is_err() {
+        let error = response.err().unwrap();
+        return Result::Err(anyhow::anyhow!(error.to_string()));
+    }
+    let response = response.unwrap().json::<CertificationStatusResponse>();
+    if response.is_err() {
+        let error = response.err().unwrap();
+        return Result::Err(anyhow::anyhow!(error.to_string()));
+    }
+    return Ok(response.unwrap());
+}
+
 pub fn check_certification_status(
     url: String,
     mode: CheckCertificationMode,
     hardware_info: &CertificationStatusRequest,
+    cache_opt: Option<&mut HWCache>,
 ) -> Result<PublicCertificationStatus> {
-    let mut cache = HWCache::new(None);
-
+    let mut cache = &mut HWCache::new(None);
+    if !cache_opt.is_none() {
+        cache = cache_opt.unwrap();
+    }
     let cache_answer = |cache: &HWCache| {
         Ok(create_answer(
             cache,
@@ -109,7 +129,7 @@ pub fn check_certification_status(
         return cache_answer(&cache);
     }
 
-    if !cache.is_expired() {
+    if !cache.is_expired() && mode != CheckCertificationMode::Forced {
         return cache_answer(&cache);
     }
 
@@ -120,16 +140,10 @@ pub fn check_certification_status(
     let mut server_url = url.clone();
     server_url.push_str(CERT_STATUS_ENDPOINT);
     cache.begin_certification(Some(server_url.clone()), hardware_info);
-    let response = minreq::post(&server_url).with_json(hardware_info)?.send();
+    let response = send_request(server_url, hardware_info);
     if response.is_err() {
         let error = response.err().unwrap();
         cache.end_failed_certification(StaleStatus::ConnectingError, error.to_string());
-        return cache_answer(&cache);
-    }
-    let response = response.unwrap().json::<CertificationStatusResponse>();
-    if response.is_err() {
-        let error = response.err().unwrap();
-        cache.end_failed_certification(StaleStatus::ServerError, error.to_string());
         return cache_answer(&cache);
     }
     let response = response.unwrap();
@@ -156,21 +170,320 @@ pub fn check_certification_status(
 
     cache.end_success_certification(certification_status, certification_status_url);
     return Ok(create_answer(
-        &mut cache,
+        &cache,
         CertificationSource::Server,
         hardware_info,
     ));
 }
 
-pub fn send_certification_status_request(
-    url: String,
-    request: &CertificationStatusRequest,
+#[cfg(test)]
+fn send_request(
+    server_url: String,
+    _: &CertificationStatusRequest,
 ) -> Result<CertificationStatusResponse> {
-    let mut server_url = url.clone();
-    server_url.push_str(CERT_STATUS_ENDPOINT);
-    let response = minreq::post(&server_url)
-        .with_json(request)?
-        .send()?
-        .json()?;
-    return Ok(response);
+    let only_url = server_url.as_str().split("/").nth(0).unwrap();
+    if only_url.starts_with("certified_") {
+        let arch = only_url.split("_").nth(1).unwrap();
+        return Result::Ok(CertificationStatusResponse::Certified {
+            certified_url: format!("https://certification.ubuntu.com/hardware/{}", arch),
+            architecture: arch.to_string(),
+            available_releases: vec![],
+            bios: Default::default(),
+            board: Default::default(),
+            chassis: Default::default(),
+        });
+    }
+
+    if only_url.starts_with("related_certified_system_exists_") {
+        let arch = only_url.split("_").nth(4).unwrap();
+        return Result::Ok(CertificationStatusResponse::RelatedCertifiedSystemExists {
+            certified_url: format!("https://certification.ubuntu.com/hardware/{}", arch),
+            architecture: arch.to_string(),
+            available_releases: vec![],
+            bios: Default::default(),
+            board: Default::default(),
+            chassis: Default::default(),
+            gpu: None,
+            audio: None,
+            video: None,
+            network: None,
+            wireless: None,
+            pci_peripherals: vec![],
+            usb_peripherals: vec![],
+        });
+    }
+
+    if only_url.starts_with("certified_image_exists_") {
+        let arch = only_url.split("_").nth(3).unwrap();
+        return Result::Ok(CertificationStatusResponse::CertifiedImageExists {
+            certified_url: format!("https://certification.ubuntu.com/hardware/{}", arch),
+            architecture: arch.to_string(),
+            available_releases: vec![],
+            bios: Default::default(),
+            board: Default::default(),
+            chassis: Default::default(),
+        });
+    }
+
+    return Result::Ok(CertificationStatusResponse::NotSeen);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::software::OS;
+    use crate::models::{
+        devices::{Board, Processor},
+        software::KernelPackage,
+    };
+    use test_temp_dir::{test_temp_dir, TestTempDir};
+
+    fn create_test_hardware_data(arch: String) -> CertificationStatusRequest {
+        CertificationStatusRequest {
+            architecture: arch,
+            bios: None,
+            board: Board::default(),
+            chassis: None,
+            model: "".to_string(),
+            os: OS {
+                codename: "".to_string(),
+                distributor: "".to_string(),
+                version: "".to_string(),
+                kernel: KernelPackage {
+                    name: None,
+                    version: "".to_string(),
+                    signature: None,
+                    loaded_modules: vec![],
+                },
+            },
+            pci_peripherals: vec![],
+            processor: Processor {
+                identifier: None,
+                frequency: 0,
+                version: "".to_string(),
+                manufacturer: "".to_string(),
+            },
+            usb_peripherals: vec![],
+            vendor: "".to_string(),
+        }
+    }
+
+    fn create_temporal_cache_folder() -> TestTempDir {
+        // Ensures that each test runs in a separate temporary directory. Can't
+        // just set SNAP_DATA to a new temp dir because the tests seem to run in
+        // parallel, so the variable would be overwritten.
+        let temp_dir = test_temp_dir!();
+        return temp_dir;
+    }
+
+    fn keep_temp_dir_alive(_temp_dir: &TestTempDir) {
+        // Keep the temp dir alive until the end of the test
+    }
+
+    #[test]
+    fn test_check_is_certified() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_check_first_call_no_connection() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Unknown);
+        assert_eq!(data.source, CertificationSource::Cache);
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_check_is_certified_and_cached() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Cache);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+    }
+
+    #[test]
+    fn test_check_is_certified_forced() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Forced,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_check_is_certified_hardware_mismatch() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+
+        let hardware_info = create_test_hardware_data("arm64".to_string());
+        let result = check_certification_status(
+            "certified_arm64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Cache);
+        assert_eq!(data.hardware_mismatch, true);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+
+        let hardware_info = create_test_hardware_data("arm64".to_string());
+        let result = check_certification_status(
+            "certified_arm64".to_string(),
+            CheckCertificationMode::Forced,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_check_is_certified_and_cached_in_cache_mode() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "certified_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+
+        let hardware_info = create_test_hardware_data("arm64".to_string());
+        let result = check_certification_status(
+            "certified_arm64".to_string(),
+            CheckCertificationMode::Cached,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Cache);
+        assert_eq!(data.hardware_mismatch, true);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+    }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -37,7 +37,7 @@ use models::{
     response_validators::CertificationStatusResponse, software::OS,
 };
 
-use cache::{CertificationStatus, HWCache, StaleStatus};
+pub use cache::{CertificationStatus, HWCache, StaleStatus};
 use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq)]
@@ -75,7 +75,7 @@ impl PublicCertificationStatus {
         );
     }
 
-    pub fn is_staled(&self) -> (bool, Option<String>) {
+    pub fn stale_status(&self) -> (bool, Option<String>) {
         return (self.stale, self.stale_reason.clone());
     }
 }
@@ -108,12 +108,12 @@ fn send_request(
     let response = minreq::post(&server_url).with_json(hardware_info)?.send();
     if response.is_err() {
         let error = response.err().unwrap();
-        return Result::Err(anyhow::anyhow!(error.to_string()));
+        return Result::Err(anyhow::anyhow!("Connecting error: {}", error.to_string()));
     }
     let response = response.unwrap().json::<CertificationStatusResponse>();
     if response.is_err() {
         let error = response.err().unwrap();
-        return Result::Err(anyhow::anyhow!(error.to_string()));
+        return Result::Err(anyhow::anyhow!("Server error: {}", error.to_string()));
     }
     return Ok(response.unwrap());
 }
@@ -123,19 +123,14 @@ pub fn check_certification_status(
     mode: CheckCertificationMode,
     hardware_info: &CertificationStatusRequest,
     cache_opt: Option<&mut HWCache>,
-) -> Result<PublicCertificationStatus> {
+) -> PublicCertificationStatus {
     let mut local_cache = HWCache::new(None);
     let cache: &mut HWCache = match cache_opt {
         Some(cache) => cache,
         None => &mut local_cache,
     };
-    let cache_answer = |cache: &HWCache| {
-        Ok(create_answer(
-            cache,
-            CertificationSource::Cache,
-            hardware_info,
-        ))
-    };
+    let cache_answer =
+        |cache: &HWCache| create_answer(cache, CertificationSource::Cache, hardware_info);
 
     if mode == CheckCertificationMode::Cached {
         return cache_answer(cache);
@@ -163,7 +158,14 @@ pub fn check_certification_status(
     let response = send_request(server_url, hardware_info);
     if response.is_err() {
         let error = response.err().unwrap();
-        cache.end_failed_certification(StaleStatus::ConnectingError, error.to_string());
+        cache.end_failed_certification(
+            if error.to_string().starts_with("Connecting error:") {
+                StaleStatus::ConnectingError
+            } else {
+                StaleStatus::ServerError
+            },
+            error.to_string(),
+        );
         return cache_answer(cache);
     }
     let response = response.unwrap();
@@ -210,11 +212,7 @@ pub fn check_certification_status(
         certification_certified_url,
         certification_available_releases,
     );
-    return Ok(create_answer(
-        cache,
-        CertificationSource::Server,
-        hardware_info,
-    ));
+    return create_answer(cache, CertificationSource::Server, hardware_info);
 }
 
 #[cfg(test)]
@@ -266,6 +264,11 @@ fn send_request(
         });
     }
 
+    if only_url.starts_with("connectionerror") {
+        return Result::Err(anyhow::anyhow!(
+            "Connecting error: simulated connection error"
+        ));
+    }
     return Result::Ok(CertificationStatusResponse::NotSeen);
 }
 
@@ -322,20 +325,36 @@ mod tests {
     }
 
     #[test]
+    fn test_connection_error() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let _ = check_certification_status(
+            "connectionerror_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        let (_, _, staled, _) = cache.get_status();
+        assert!(staled == StaleStatus::ConnectingError);
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
     fn test_check_certified_image_exists() {
         let temp_dir = create_temporal_cache_folder();
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certifiedimageexists_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::CertifiedImageExists);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
@@ -351,14 +370,12 @@ mod tests {
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
@@ -374,14 +391,12 @@ mod tests {
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "relatedcertifiedsystemexists_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(
             data.status,
             CertificationStatus::RelatedCertifiedSystemExists
@@ -400,14 +415,12 @@ mod tests {
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "not_seen_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::NotSeen);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
@@ -422,14 +435,12 @@ mod tests {
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Unknown);
         assert_eq!(data.source, CertificationSource::Cache);
         keep_temp_dir_alive(&temp_dir);
@@ -442,28 +453,24 @@ mod tests {
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
         assert_eq!(data.valid_cache, true);
         assert_eq!(data.stale, false);
 
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Cache);
         assert_eq!(data.hardware_mismatch, false);
@@ -478,28 +485,24 @@ mod tests {
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
         assert_eq!(data.valid_cache, true);
         assert_eq!(data.stale, false);
 
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Forced,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
@@ -516,14 +519,12 @@ mod tests {
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
@@ -531,14 +532,12 @@ mod tests {
         assert_eq!(data.stale, false);
 
         let hardware_info = create_test_hardware_data("arm64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_arm64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Cache);
         assert_eq!(data.hardware_mismatch, true);
@@ -546,14 +545,12 @@ mod tests {
         assert_eq!(data.stale, false);
 
         let hardware_info = create_test_hardware_data("arm64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_arm64".to_string(),
             CheckCertificationMode::Forced,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
@@ -570,14 +567,12 @@ mod tests {
         cache.set_remote_access_enabled(true);
 
         let hardware_info = create_test_hardware_data("x86_64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_x86_64".to_string(),
             CheckCertificationMode::Normal,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
@@ -585,14 +580,12 @@ mod tests {
         assert_eq!(data.stale, false);
 
         let hardware_info = create_test_hardware_data("arm64".to_string());
-        let result = check_certification_status(
+        let data = check_certification_status(
             "certified_arm64".to_string(),
             CheckCertificationMode::Cached,
             &hardware_info,
             Some(&mut cache),
         );
-        assert!(result.is_ok());
-        let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
         assert_eq!(data.source, CertificationSource::Cache);
         assert_eq!(data.hardware_mismatch, true);

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -34,11 +34,11 @@ use anyhow::Result;
 use constants::CERT_STATUS_ENDPOINT;
 use models::{
     request_validators::CertificationStatusRequest,
-    response_validators::CertificationStatusResponse,
+    response_validators::CertificationStatusResponse, software::OS,
 };
 
 use cache::{CertificationStatus, HWCache, StaleStatus};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq)]
 pub enum CheckCertificationMode {
@@ -47,16 +47,17 @@ pub enum CheckCertificationMode {
     Forced,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum CertificationSource {
     Cache,
     Server,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct PublicCertificationStatus {
     status: CertificationStatus,
-    status_url: Option<String>,
+    certified_url: Option<String>,
+    available_releases: Vec<OS>,
     valid_cache: bool,
     hardware_mismatch: bool,
     stale: bool,
@@ -65,17 +66,32 @@ pub struct PublicCertificationStatus {
     remote_access_enabled: bool,
 }
 
+impl PublicCertificationStatus {
+    pub fn get_status(&self) -> (CertificationStatus, Option<String>, Vec<OS>) {
+        return (
+            self.status.clone(),
+            self.certified_url.clone(),
+            self.available_releases.clone(),
+        );
+    }
+
+    pub fn is_staled(&self) -> (bool, Option<String>) {
+        return (self.stale, self.stale_reason.clone());
+    }
+}
+
 fn create_answer(
     cache: &HWCache,
     source: CertificationSource,
     hardware_info: &CertificationStatusRequest,
 ) -> PublicCertificationStatus {
-    let (certification_status, certification_status_url, stale_status, stale_reason) =
+    let (certification_status, certification_certified_url, stale_status, stale_reason) =
         cache.get_status();
     return PublicCertificationStatus {
         status: certification_status,
-        status_url: certification_status_url,
+        certified_url: certification_certified_url,
         valid_cache: !cache.is_expired(),
+        available_releases: cache.get_available_releases(),
         hardware_mismatch: !cache.compare_hardware_data(hardware_info),
         stale: stale_status != StaleStatus::Valid,
         stale_reason: stale_reason,
@@ -125,7 +141,10 @@ pub fn check_certification_status(
     }
 
     let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
-    if !cache.get_remote_access_enabled() && hardware_mismatch {
+    if !cache.get_remote_access_enabled()
+        && hardware_mismatch
+        && mode != CheckCertificationMode::Forced
+    {
         return cache_answer(&cache);
     }
 
@@ -148,27 +167,48 @@ pub fn check_certification_status(
     }
     let response = response.unwrap();
     let certification_status: CertificationStatus;
-    let certification_status_url: Option<String>;
+    let certification_certified_url: Option<String>;
+    let certification_available_releases: Vec<OS>;
     match response {
-        CertificationStatusResponse::Certified { certified_url, .. } => {
+        CertificationStatusResponse::Certified {
+            certified_url,
+            available_releases,
+            ..
+        } => {
             certification_status = CertificationStatus::Certified;
-            certification_status_url = Some(certified_url);
+            certification_certified_url = Some(certified_url);
+            certification_available_releases = available_releases;
         }
-        CertificationStatusResponse::CertifiedImageExists { certified_url, .. } => {
+        CertificationStatusResponse::CertifiedImageExists {
+            certified_url,
+            available_releases,
+            ..
+        } => {
             certification_status = CertificationStatus::CertifiedImageExists;
-            certification_status_url = Some(certified_url);
+            certification_certified_url = Some(certified_url);
+            certification_available_releases = available_releases;
         }
-        CertificationStatusResponse::RelatedCertifiedSystemExists { certified_url, .. } => {
+        CertificationStatusResponse::RelatedCertifiedSystemExists {
+            certified_url,
+            available_releases,
+            ..
+        } => {
             certification_status = CertificationStatus::RelatedCertifiedSystemExists;
-            certification_status_url = Some(certified_url);
+            certification_certified_url = Some(certified_url);
+            certification_available_releases = available_releases;
         }
         _ => {
             certification_status = CertificationStatus::NotSeen;
-            certification_status_url = None;
+            certification_certified_url = None;
+            certification_available_releases = vec![];
         }
     }
 
-    cache.end_success_certification(certification_status, certification_status_url);
+    cache.end_success_certification(
+        certification_status,
+        certification_certified_url,
+        certification_available_releases,
+    );
     return Ok(create_answer(
         &cache,
         CertificationSource::Server,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -65,15 +65,13 @@ pub struct PublicCertificationStatus {
 }
 
 fn create_answer(
-    cache: &mut HWCache,
+    cache: &HWCache,
     source: CertificationSource,
     hardware_info: &CertificationStatusRequest,
 ) -> PublicCertificationStatus {
     let (certification_status, stale_status, stale_reason) = cache.get_status();
-
     let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
-
-    PublicCertificationStatus {
+    return PublicCertificationStatus {
         status: certification_status,
         valid_cache: !cache.is_expired(),
         hardware_mismatch: hardware_mismatch,
@@ -81,7 +79,7 @@ fn create_answer(
         stale_reason: stale_reason,
         source: source,
         remote_access_enabled: cache.get_remote_access_enabled(),
-    }
+    };
 }
 
 pub fn check_certification_status(
@@ -91,37 +89,29 @@ pub fn check_certification_status(
 ) -> Result<PublicCertificationStatus> {
     let mut cache = HWCache::new(None);
 
+    let cache_answer = |cache: &HWCache| {
+        Ok(create_answer(
+                cache,
+                CertificationSource::Cache,
+                hardware_info,
+        ))
+    };
+
     if mode == CheckCertificationMode::Cached {
-        return Ok(create_answer(
-            &mut cache,
-            CertificationSource::Cache,
-            hardware_info,
-        ));
+        return cache_answer(&cache);
     }
 
     let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
     if !cache.get_remote_access_enabled() && hardware_mismatch {
-        return Ok(create_answer(
-            &mut cache,
-            CertificationSource::Cache,
-            hardware_info,
-        ));
+        return cache_answer(&cache);
     }
 
     if !cache.is_expired() {
-        return Ok(create_answer(
-            &mut cache,
-            CertificationSource::Cache,
-            hardware_info,
-        ));
+        return cache_answer(&cache);
     }
 
     if !cache.get_remote_access_enabled() && mode != CheckCertificationMode::Forced {
-        return Ok(create_answer(
-            &mut cache,
-            CertificationSource::Cache,
-            hardware_info,
-        ));
+        return cache_answer(&cache);
     }
 
     let mut server_url = url.clone();
@@ -131,21 +121,13 @@ pub fn check_certification_status(
     if response.is_err() {
         let error = response.err().unwrap();
         cache.end_failed_certification(StaleStatus::ConnectingError, error.to_string());
-        return Ok(create_answer(
-            &mut cache,
-            CertificationSource::Cache,
-            hardware_info,
-        ));
+        return cache_answer(&cache);
     }
     let response = response.unwrap().json::<CertificationStatusResponse>();
     if response.is_err() {
         let error = response.err().unwrap();
         cache.end_failed_certification(StaleStatus::ServerError, error.to_string());
-        return Ok(create_answer(
-            &mut cache,
-            CertificationSource::Cache,
-            hardware_info,
-        ));
+        return cache_answer(&cache);
     }
     let response = response.unwrap();
     let certification_status: CertificationStatus;
@@ -165,11 +147,11 @@ pub fn check_certification_status(
     }
 
     cache.end_success_certification(certification_status);
-    Ok(create_answer(
+    return Ok(create_answer(
         &mut cache,
         CertificationSource::Server,
         hardware_info,
-    ))
+    ));
 }
 
 pub fn send_certification_status_request(
@@ -182,5 +164,5 @@ pub fn send_certification_status_request(
         .with_json(request)?
         .send()?
         .json()?;
-    Ok(response)
+    return Ok(response);
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -21,6 +21,7 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+mod cache;
 pub mod collectors;
 mod constants;
 mod helpers;
@@ -35,6 +36,141 @@ use models::{
     request_validators::CertificationStatusRequest,
     response_validators::CertificationStatusResponse,
 };
+
+use cache::{CertificationStatus, HWCache, StaleStatus};
+use serde::Serialize;
+
+#[derive(PartialEq)]
+pub enum CheckCertificationMode {
+    Normal,
+    Cached,
+    Forced,
+}
+
+#[derive(Serialize, Debug)]
+pub enum CertificationSource {
+    Cache,
+    Server,
+}
+
+#[derive(Serialize, Debug)]
+pub struct PublicCertificationStatus {
+    status: CertificationStatus,
+    valid_cache: bool,
+    hardware_mismatch: bool,
+    stale: bool,
+    stale_reason: Option<String>,
+    source: CertificationSource,
+    remote_access_enabled: bool,
+}
+
+fn create_answer(
+    cache: &mut HWCache,
+    source: CertificationSource,
+    hardware_info: &CertificationStatusRequest,
+) -> PublicCertificationStatus {
+    let (certification_status, stale_status, stale_reason) = cache.get_status();
+
+    let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
+
+    PublicCertificationStatus {
+        status: certification_status,
+        valid_cache: !cache.is_expired(),
+        hardware_mismatch: hardware_mismatch,
+        stale: stale_status != StaleStatus::Valid,
+        stale_reason: stale_reason,
+        source: source,
+        remote_access_enabled: cache.get_remote_access_enabled(),
+    }
+}
+
+pub fn check_certification_status(
+    url: String,
+    mode: CheckCertificationMode,
+    hardware_info: &CertificationStatusRequest,
+) -> Result<PublicCertificationStatus> {
+    let mut cache = HWCache::new();
+
+    if mode == CheckCertificationMode::Cached {
+        return Ok(create_answer(
+            &mut cache,
+            CertificationSource::Cache,
+            hardware_info,
+        ));
+    }
+
+    let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
+    if !cache.get_remote_access_enabled() && hardware_mismatch {
+        return Ok(create_answer(
+            &mut cache,
+            CertificationSource::Cache,
+            hardware_info,
+        ));
+    }
+
+    if !cache.is_expired() {
+        return Ok(create_answer(
+            &mut cache,
+            CertificationSource::Cache,
+            hardware_info,
+        ));
+    }
+
+    if !cache.get_remote_access_enabled() && mode != CheckCertificationMode::Forced {
+        return Ok(create_answer(
+            &mut cache,
+            CertificationSource::Cache,
+            hardware_info,
+        ));
+    }
+
+    let mut server_url = url.clone();
+    server_url.push_str(CERT_STATUS_ENDPOINT);
+    cache.begin_certification(Some(server_url.clone()), hardware_info);
+    let response = minreq::post(&server_url).with_json(hardware_info)?.send();
+    if response.is_err() {
+        let error = response.err().unwrap();
+        cache.end_failed_certification(StaleStatus::ConnectingError, error.to_string());
+        return Ok(create_answer(
+            &mut cache,
+            CertificationSource::Cache,
+            hardware_info,
+        ));
+    }
+    let response = response.unwrap().json::<CertificationStatusResponse>();
+    if response.is_err() {
+        let error = response.err().unwrap();
+        cache.end_failed_certification(StaleStatus::ServerError, error.to_string());
+        return Ok(create_answer(
+            &mut cache,
+            CertificationSource::Cache,
+            hardware_info,
+        ));
+    }
+    let response = response.unwrap();
+    let certification_status: CertificationStatus;
+    match response {
+        CertificationStatusResponse::Certified { .. } => {
+            certification_status = CertificationStatus::Certified;
+        }
+        CertificationStatusResponse::CertifiedImageExists { .. } => {
+            certification_status = CertificationStatus::Certified;
+        }
+        CertificationStatusResponse::RelatedCertifiedSystemExists { .. } => {
+            certification_status = CertificationStatus::RelatedCertifiedSystemExists;
+        }
+        _ => {
+            certification_status = CertificationStatus::NotSeen;
+        }
+    }
+
+    cache.end_success_certification(certification_status);
+    Ok(create_answer(
+        &mut cache,
+        CertificationSource::Server,
+        hardware_info,
+    ))
+}
 
 pub fn send_certification_status_request(
     url: String,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -321,6 +321,29 @@ mod tests {
     }
 
     #[test]
+    fn test_check_certified_image_exists() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "certified_image_exists_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::CertifiedImageExists);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
     fn test_check_is_certified() {
         let temp_dir = create_temporal_cache_folder();
         let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
@@ -336,6 +359,55 @@ mod tests {
         assert!(result.is_ok());
         let data = result.unwrap();
         assert_eq!(data.status, CertificationStatus::Certified);
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_check_related_certified() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "related_certified_system_exists_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(
+            data.status,
+            CertificationStatus::RelatedCertifiedSystemExists
+        );
+        assert_eq!(data.source, CertificationSource::Server);
+        assert_eq!(data.hardware_mismatch, false);
+        assert_eq!(data.valid_cache, true);
+        assert_eq!(data.stale, false);
+        keep_temp_dir_alive(&temp_dir);
+    }
+
+    #[test]
+    fn test_check_not_seen() {
+        let temp_dir = create_temporal_cache_folder();
+        let mut cache = HWCache::new(Some(temp_dir.as_path_untracked()));
+        cache.set_remote_access_enabled(true);
+
+        let hardware_info = create_test_hardware_data("x86_64".to_string());
+        let result = check_certification_status(
+            "not_seen_x86_64".to_string(),
+            CheckCertificationMode::Normal,
+            &hardware_info,
+            Some(&mut cache),
+        );
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.status, CertificationStatus::NotSeen);
         assert_eq!(data.source, CertificationSource::Server);
         assert_eq!(data.hardware_mismatch, false);
         assert_eq!(data.valid_cache, true);

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -124,10 +124,11 @@ pub fn check_certification_status(
     hardware_info: &CertificationStatusRequest,
     cache_opt: Option<&mut HWCache>,
 ) -> Result<PublicCertificationStatus> {
-    let mut cache = &mut HWCache::new(None);
-    if cache_opt.is_some() {
-        cache = cache_opt.unwrap();
-    }
+    let mut local_cache = HWCache::new(None);
+    let cache: &mut HWCache = match cache_opt {
+        Some(cache) => cache,
+        None => &mut local_cache,
+    };
     let cache_answer = |cache: &HWCache| {
         Ok(create_answer(
             cache,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -56,6 +56,7 @@ pub enum CertificationSource {
 #[derive(Serialize, Debug)]
 pub struct PublicCertificationStatus {
     status: CertificationStatus,
+    status_url: Option<String>,
     valid_cache: bool,
     hardware_mismatch: bool,
     stale: bool,
@@ -69,10 +70,12 @@ fn create_answer(
     source: CertificationSource,
     hardware_info: &CertificationStatusRequest,
 ) -> PublicCertificationStatus {
-    let (certification_status, stale_status, stale_reason) = cache.get_status();
+    let (certification_status, certification_status_url, stale_status, stale_reason) =
+        cache.get_status();
     let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
     return PublicCertificationStatus {
         status: certification_status,
+        status_url: certification_status_url,
         valid_cache: !cache.is_expired(),
         hardware_mismatch: hardware_mismatch,
         stale: stale_status != StaleStatus::Valid,
@@ -91,9 +94,9 @@ pub fn check_certification_status(
 
     let cache_answer = |cache: &HWCache| {
         Ok(create_answer(
-                cache,
-                CertificationSource::Cache,
-                hardware_info,
+            cache,
+            CertificationSource::Cache,
+            hardware_info,
         ))
     };
 
@@ -131,22 +134,27 @@ pub fn check_certification_status(
     }
     let response = response.unwrap();
     let certification_status: CertificationStatus;
+    let certification_status_url: Option<String>;
     match response {
-        CertificationStatusResponse::Certified { .. } => {
+        CertificationStatusResponse::Certified { certified_url, .. } => {
             certification_status = CertificationStatus::Certified;
+            certification_status_url = Some(certified_url);
         }
-        CertificationStatusResponse::CertifiedImageExists { .. } => {
-            certification_status = CertificationStatus::Certified;
+        CertificationStatusResponse::CertifiedImageExists { certified_url, .. } => {
+            certification_status = CertificationStatus::CertifiedImageExists;
+            certification_status_url = Some(certified_url);
         }
-        CertificationStatusResponse::RelatedCertifiedSystemExists { .. } => {
+        CertificationStatusResponse::RelatedCertifiedSystemExists { certified_url, .. } => {
             certification_status = CertificationStatus::RelatedCertifiedSystemExists;
+            certification_status_url = Some(certified_url);
         }
         _ => {
             certification_status = CertificationStatus::NotSeen;
+            certification_status_url = None;
         }
     }
 
-    cache.end_success_certification(certification_status);
+    cache.end_success_certification(certification_status, certification_status_url);
     return Ok(create_answer(
         &mut cache,
         CertificationSource::Server,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -89,7 +89,7 @@ pub fn check_certification_status(
     mode: CheckCertificationMode,
     hardware_info: &CertificationStatusRequest,
 ) -> Result<PublicCertificationStatus> {
-    let mut cache = HWCache::new();
+    let mut cache = HWCache::new(None);
 
     if mode == CheckCertificationMode::Cached {
         return Ok(create_answer(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -94,8 +94,8 @@ fn create_answer(
         available_releases: cache.get_available_releases(),
         hardware_mismatch: !cache.compare_hardware_data(hardware_info),
         stale: stale_status != StaleStatus::Valid,
-        stale_reason: stale_reason,
-        source: source,
+        stale_reason,
+        source,
         remote_access_enabled: cache.get_remote_access_enabled(),
     };
 }
@@ -125,7 +125,7 @@ pub fn check_certification_status(
     cache_opt: Option<&mut HWCache>,
 ) -> Result<PublicCertificationStatus> {
     let mut cache = &mut HWCache::new(None);
-    if !cache_opt.is_none() {
+    if cache_opt.is_some() {
         cache = cache_opt.unwrap();
     }
     let cache_answer = |cache: &HWCache| {
@@ -137,7 +137,7 @@ pub fn check_certification_status(
     };
 
     if mode == CheckCertificationMode::Cached {
-        return cache_answer(&cache);
+        return cache_answer(cache);
     }
 
     let hardware_mismatch = !cache.compare_hardware_data(hardware_info);
@@ -145,15 +145,15 @@ pub fn check_certification_status(
         && hardware_mismatch
         && mode != CheckCertificationMode::Forced
     {
-        return cache_answer(&cache);
+        return cache_answer(cache);
     }
 
     if !cache.is_expired() && mode != CheckCertificationMode::Forced {
-        return cache_answer(&cache);
+        return cache_answer(cache);
     }
 
     if !cache.get_remote_access_enabled() && mode != CheckCertificationMode::Forced {
-        return cache_answer(&cache);
+        return cache_answer(cache);
     }
 
     let mut server_url = url.clone();
@@ -163,7 +163,7 @@ pub fn check_certification_status(
     if response.is_err() {
         let error = response.err().unwrap();
         cache.end_failed_certification(StaleStatus::ConnectingError, error.to_string());
-        return cache_answer(&cache);
+        return cache_answer(cache);
     }
     let response = response.unwrap();
     let certification_status: CertificationStatus;
@@ -210,7 +210,7 @@ pub fn check_certification_status(
         certification_available_releases,
     );
     return Ok(create_answer(
-        &cache,
+        cache,
         CertificationSource::Server,
         hardware_info,
     ));
@@ -221,7 +221,7 @@ fn send_request(
     server_url: String,
     _: &CertificationStatusRequest,
 ) -> Result<CertificationStatusResponse> {
-    let only_url = server_url.as_str().split("/").nth(0).unwrap();
+    let only_url = server_url.as_str().split("/").next().unwrap();
     if only_url.starts_with("certified_") {
         let arch = only_url.split("_").nth(1).unwrap();
         return Result::Ok(CertificationStatusResponse::Certified {

--- a/client/src/models/devices.rs
+++ b/client/src/models/devices.rs
@@ -25,7 +25,7 @@ pub struct Audio {
     pub vendor: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Bios {
     pub firmware_revision: Option<String>,
     pub release_date: Option<String>,
@@ -34,14 +34,14 @@ pub struct Bios {
     pub version: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone)]
 pub struct Board {
     pub manufacturer: String,
     pub product_name: String,
     pub version: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Chassis {
     pub chassis_type: String,
     pub manufacturer: String,
@@ -49,7 +49,7 @@ pub struct Chassis {
     pub version: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct GPU {
     pub codename: Option<String>,
     pub identifier: String,
@@ -58,7 +58,7 @@ pub struct GPU {
     pub version: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct NetworkAdapter {
     pub bus: String,
     pub capacity: i32,
@@ -67,7 +67,7 @@ pub struct NetworkAdapter {
     pub vendor: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct PCIPeripheral {
     pub pci_id: String,
     pub name: String,
@@ -75,7 +75,7 @@ pub struct PCIPeripheral {
     pub vendor: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Processor {
     pub identifier: Option<[u8; 8]>,
     pub frequency: u64,
@@ -83,7 +83,7 @@ pub struct Processor {
     pub version: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct USBPeripheral {
     pub usb_id: String,
     pub name: String,
@@ -91,7 +91,7 @@ pub struct USBPeripheral {
     pub vendor: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct VideoCapture {
     pub identifier: String,
     pub model: String,
@@ -99,7 +99,7 @@ pub struct VideoCapture {
     pub vendor: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct WirelessAdapter {
     pub identifier: String,
     pub model: String,
@@ -107,7 +107,7 @@ pub struct WirelessAdapter {
     pub vendor: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum DeviceStatus {
     Working,
     Breaking,

--- a/client/src/models/devices.rs
+++ b/client/src/models/devices.rs
@@ -25,7 +25,7 @@ pub struct Audio {
     pub vendor: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone)]
 pub struct Bios {
     pub firmware_revision: Option<String>,
     pub release_date: Option<String>,

--- a/client/src/models/request_validators.rs
+++ b/client/src/models/request_validators.rs
@@ -74,7 +74,7 @@ impl Default for Paths {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct CertificationStatusRequest {
     pub architecture: String,
     pub bios: Option<Bios>,

--- a/client/src/models/software.rs
+++ b/client/src/models/software.rs
@@ -18,7 +18,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct KernelPackage {
     pub name: Option<String>,
     pub version: String,
@@ -26,7 +26,7 @@ pub struct KernelPackage {
     pub loaded_modules: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct OS {
     pub codename: String,
     pub distributor: String,

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -28,7 +28,7 @@ use pyo3::{
 use serde_json;
 
 /// This function creates and sends the certification status request to the specified
-/// hardware-api server URL.
+/// hardware-api server URL. It keeps backward compatibility with the previous version of the function that returned a JSON string.
 #[pyfunction]
 fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     let request_body = CertificationStatusRequest::new(Paths::default())
@@ -44,8 +44,38 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     Ok(json_object)
 }
 
+/// This function gives full access to the new cache functionality.
+/// Normal mode is the default mode, which checks the cache first and then queries the server if needed.
+/// Forced mode always queries the server and updates the cache.
+/// Cached mode returns always the cache and does not query the server.
+#[pyfunction]
+fn check_certification_status(py: Python, url: String, mode: String) -> PyResult<Py<PyAny>> {
+    let mode = match mode.as_str() {
+        "forced" => CheckCertificationMode::Forced,
+        "cached" => CheckCertificationMode::Cached,
+        "normal" => CheckCertificationMode::Normal,
+        _ => {
+            return Err(PyRuntimeError::new_err(format!(
+                "Invalid mode: {}. Valid modes are 'normal', 'forced' and 'cached'.",
+                mode
+            )))
+        }
+    };
+    let request_body = CertificationStatusRequest::new(Paths::default())
+        .map_err(|e| PyRuntimeError::new_err(format!("failed to create request: {e}")))?;
+
+    let response = native_check_certification_status(url, mode, &request_body, None);
+
+    let json_str = serde_json::json!(response).to_string();
+    let json = PyString::new(py, &json_str);
+    let json_module = py.import("json")?;
+    let json_object: Py<PyAny> = json_module.call_method1("loads", (json,))?.into();
+    Ok(json_object)
+}
+
 #[pymodule]
 fn hwlib(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(send_certification_request, m)?)?;
+    m.add_function(wrap_pyfunction!(check_certification_status, m)?)?;
     Ok(())
 }

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -58,12 +58,12 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
 #[pyfunction]
 fn check_certification_status(py: Python, url: String, mode: String) -> PyResult<Py<PyAny>> {
     let mode = match mode.as_str() {
-        "forced" => CheckCertificationMode::Forced,
-        "cached" => CheckCertificationMode::Cached,
-        "normal" => CheckCertificationMode::Normal,
+        "server" => CheckCertificationMode::Server,
+        "cache" => CheckCertificationMode::Cache,
+        "auto" => CheckCertificationMode::Auto,
         _ => {
             return Err(PyRuntimeError::new_err(format!(
-                "Invalid mode: {}. Valid modes are 'normal', 'forced' and 'cached'.",
+                "Invalid mode: {}. Valid modes are 'auto', 'server' and 'cache'.",
                 mode
             )))
         }

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -37,7 +37,7 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     let response =
         native_check_certification_status(url, CheckCertificationMode::Forced, &request_body, None);
 
-    let json_str = serde_json::json!(response_value).to_string();
+    let json_str = serde_json::json!(response).to_string();
     let json = PyString::new(py, &json_str);
     let json_module = py.import("json")?;
     let json_object: Py<PyAny> = json_module.call_method1("loads", (json,))?.into();

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -37,10 +37,9 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     let response =
         native_check_certification_status(url, CheckCertificationMode::Forced, &request_body, None);
 
-    if response.is_staled() {
-        let e = response
-            .stale_reason()
-            .unwrap_or("unknown reason".to_string());
+    let (staled, stale_reason) = response.stale_status();
+    if staled {
+        let e = stale_reason.unwrap_or("unknown reason".to_string());
         return Err(PyErr::new::<PyRuntimeError, _>(format!(
             "Request failed: {e}"
         )));

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -17,8 +17,9 @@
  */
 
 use crate::{
+    check_certification_status as native_check_certification_status,
     models::request_validators::{CertificationStatusRequest, Paths},
-    send_certification_status_request as native_send_certification_status_request,
+    CheckCertificationMode,
 };
 use pyo3::{
     exceptions::PyRuntimeError, prelude::*, types::PyString, wrap_pyfunction, Py, PyAny, PyResult,
@@ -33,7 +34,8 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     let request_body = CertificationStatusRequest::new(Paths::default())
         .map_err(|e| PyRuntimeError::new_err(format!("failed to create request: {e}")))?;
 
-    let response = native_send_certification_status_request(url, &request_body);
+    let response =
+        native_check_certification_status(url, CheckCertificationMode::Forced, &request_body, None);
 
     match response {
         Ok(response_value) => {

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -38,6 +38,9 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
         native_check_certification_status(url, CheckCertificationMode::Forced, &request_body, None);
 
     if response.is_staled() {
+        let e = response
+            .stale_reason()
+            .unwrap_or("unknown reason".to_string());
         return Err(PyErr::new::<PyRuntimeError, _>(format!(
             "Request failed: {e}"
         )));

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -19,7 +19,7 @@
 use crate::{
     check_certification_status as native_check_certification_status,
     models::request_validators::{CertificationStatusRequest, Paths},
-    CheckCertificationMode,
+    CheckCertificationSource,
 };
 use pyo3::{
     exceptions::PyRuntimeError, prelude::*, types::PyString, wrap_pyfunction, Py, PyAny, PyResult,
@@ -34,8 +34,12 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     let request_body = CertificationStatusRequest::new(Paths::default())
         .map_err(|e| PyRuntimeError::new_err(format!("failed to create request: {e}")))?;
 
-    let response =
-        native_check_certification_status(url, CheckCertificationMode::Forced, &request_body, None);
+    let response = native_check_certification_status(
+        url,
+        CheckCertificationSource::Server,
+        &request_body,
+        None,
+    );
 
     let (staled, stale_reason) = response.stale_status();
     if staled {

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -37,11 +37,16 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     let response =
         native_check_certification_status(url, CheckCertificationMode::Forced, &request_body, None);
 
+    if response.is_staled() {
+        return Err(PyErr::new::<PyRuntimeError, _>(format!(
+            "Request failed: {e}"
+        )));
+    }
     let json_str = serde_json::json!(response).to_string();
     let json = PyString::new(py, &json_str);
     let json_module = py.import("json")?;
     let json_object: Py<PyAny> = json_module.call_method1("loads", (json,))?.into();
-    Ok(json_object)
+    return Ok(json_object);
 }
 
 /// This function gives full access to the new cache functionality.

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -62,9 +62,9 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
 #[pyfunction]
 fn check_certification_status(py: Python, url: String, mode: String) -> PyResult<Py<PyAny>> {
     let mode = match mode.as_str() {
-        "server" => CheckCertificationMode::Server,
-        "cache" => CheckCertificationMode::Cache,
-        "auto" => CheckCertificationMode::Auto,
+        "server" => CheckCertificationSource::Server,
+        "cache" => CheckCertificationSource::Cache,
+        "auto" => CheckCertificationSource::Auto,
         _ => {
             return Err(PyRuntimeError::new_err(format!(
                 "Invalid mode: {}. Valid modes are 'auto', 'server' and 'cache'.",

--- a/client/src/py_bindings.rs
+++ b/client/src/py_bindings.rs
@@ -37,18 +37,11 @@ fn send_certification_request(py: Python, url: String) -> PyResult<Py<PyAny>> {
     let response =
         native_check_certification_status(url, CheckCertificationMode::Forced, &request_body, None);
 
-    match response {
-        Ok(response_value) => {
-            let json_str = serde_json::json!(response_value).to_string();
-            let json = PyString::new(py, &json_str);
-            let json_module = py.import("json")?;
-            let json_object: Py<PyAny> = json_module.call_method1("loads", (json,))?.into();
-            Ok(json_object)
-        }
-        Err(e) => Err(PyErr::new::<PyRuntimeError, _>(format!(
-            "Request failed: {e}"
-        ))),
-    }
+    let json_str = serde_json::json!(response_value).to_string();
+    let json = PyString::new(py, &json_str);
+    let json_module = py.import("json")?;
+    let json_object: Py<PyAny> = json_module.call_method1("loads", (json,))?.into();
+    Ok(json_object)
 }
 
 #[pymodule]

--- a/client/test_data/amd64/dell_xps13/response.json
+++ b/client/test_data/amd64/dell_xps13/response.json
@@ -1,20 +1,12 @@
 {
   "status": "Certified",
   "certified_url": "https://ubuntu.com/certified/202405-34051",
-  "architecture": "amd64",
-  "bios": {
-    "vendor": "Dell",
-    "version": "1.7.0",
-    "revision": null,
-    "firmware_revision": "1.9",
-    "release_date": null
-  },
-  "board": {
-    "manufacturer": "Dell",
-    "product_name": "02395C",
-    "version": "X04"
-  },
-  "chassis": null,
+  "valid_cache": true,
+  "hardware_mismatch": false,
+  "stale": false,
+  "stale_reason": null,
+  "source": "Server",
+  "remote_access_enabled": true,
   "available_releases": [
     {
       "distributor": "Ubuntu",

--- a/client/test_data/amd64/dgx_station/response.json
+++ b/client/test_data/amd64/dgx_station/response.json
@@ -1,20 +1,12 @@
 {
   "status": "Certified",
   "certified_url": "https://ubuntu.com/certified/201711-25989",
-  "architecture": "amd64",
-  "bios": {
-    "vendor": "American Megatrends Inc.",
-    "version": "0406",
-    "revision": null,
-    "firmware_revision": null,
-    "release_date": null
-  },
-  "board": {
-    "manufacturer": "empty",
-    "product_name": "X99-E-10G WS",
-    "version": "Rev 1.xx"
-  },
-  "chassis": null,
+  "valid_cache": true,
+  "hardware_mismatch": false,
+  "stale": false,
+  "stale_reason": null,
+  "source": "Server",
+  "remote_access_enabled": true,
   "available_releases": [
     {
       "distributor": "Ubuntu",

--- a/client/test_data/amd64/thinkstation_p620/response.json
+++ b/client/test_data/amd64/thinkstation_p620/response.json
@@ -1,20 +1,11 @@
 {
   "status": "Certified",
-  "certified_url": "https://ubuntu.com/certified/202203-30052",
-  "architecture": "amd64",
-  "bios": {
-    "vendor": "Lenovo",
-    "version": "S07KT41A",
-    "revision": null,
-    "firmware_revision": "1.19",
-    "release_date": null
-  },
-  "board": {
-    "manufacturer": "Lenovo",
-    "product_name": "1046",
-    "version": "Not Defined"
-  },
-  "chassis": null,
+  "certified_url": "https://ubuntu.com/certified/202203-30052",  "valid_cache": true,
+  "hardware_mismatch": false,
+  "stale": false,
+  "stale_reason": null,
+  "source": "Server",
+  "remote_access_enabled": true,
   "available_releases": [
     {
       "distributor": "Ubuntu",

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -77,7 +77,7 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
     let api_url = std::env::var("API_URL").expect("API_URL environment variable must be specified");
 
     let cert_request = CertificationStatusRequest::new(get_test_device_paths(dir_path))?;
-    let response = check_certification_status(api_url, hwlib::CheckCertificationMode::Forced, &cert_request, None)?;
+    let response = check_certification_status(api_url, hwlib::CheckCertificationMode::Forced, &cert_request, None);
 
     let response_json_file = PathBuf::from("/app/client/test_data")
         .join(dir_path)
@@ -90,13 +90,13 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
 
 #[test]
 fn test_server_connection_error() -> Result<()> {
-    let result: Result<PublicCertificationStatus> = check_certification_status(
+    let result: PublicCertificationStatus = check_certification_status(
         "http://non-existent-server:8080".to_string(),
         hwlib::CheckCertificationMode::Forced,
         &CertificationStatusRequest::new(get_test_device_paths("amd64/dell_xps13"))?,
         None);
 
-    let (staled, _) = result.get_status();
+    let (staled, _, _) = result.get_status();
     assert!(staled); // we are expecting a stale response due to server connection error
     Ok(())
 }

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -77,7 +77,7 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
     let api_url = std::env::var("API_URL").expect("API_URL environment variable must be specified");
 
     let cert_request = CertificationStatusRequest::new(get_test_device_paths(dir_path))?;
-    let response = check_certification_status(api_url, hwlib::CheckCertificationMode::Forced, &cert_request, None);
+    let response = check_certification_status(api_url, hwlib::CheckCertificationSource::Server, &cert_request, None);
 
     let response_json_file = PathBuf::from("/app/client/test_data")
         .join(dir_path)
@@ -92,7 +92,7 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
 fn test_server_connection_error() -> Result<()> {
     let result: PublicCertificationStatus = check_certification_status(
         "http://non-existent-server:8080".to_string(),
-        hwlib::CheckCertificationMode::Forced,
+        hwlib::CheckCertificationSource::Server,
         &CertificationStatusRequest::new(get_test_device_paths("amd64/dell_xps13"))?,
         None);
 

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -19,7 +19,8 @@
 use anyhow::Result;
 use hwlib::{
     models::request_validators::{CertificationStatusRequest, Paths},
-    models::response_validators::CertificationStatusResponse,
+    check_certification_status,
+    PublicCertificationStatus,
 };
 use simple_test_case::test_case;
 use std::{
@@ -40,7 +41,7 @@ fn get_test_device_paths(device_type: &str) -> Paths {
     }
 }
 
-fn load_response_file(filepath: &Path) -> CertificationStatusResponse {
+fn load_response_file(filepath: &Path) -> PublicCertificationStatus {
     let content = read_to_string(filepath)
         .unwrap_or_else(|_| panic!("Failed to read response file: {}", filepath.display()));
     serde_json::from_str(&content)
@@ -48,63 +49,22 @@ fn load_response_file(filepath: &Path) -> CertificationStatusResponse {
 }
 
 fn assert_response_matches_expected(
-    response: &CertificationStatusResponse,
-    expected: &CertificationStatusResponse,
+    response: &PublicCertificationStatus,
+    expected: &PublicCertificationStatus,
 ) {
-    let (actual_certified_url, actual_arch, actual_bios, actual_board, actual_releases) =
-        match response {
-            CertificationStatusResponse::Certified {
-                certified_url,
-                architecture,
-                bios,
-                board,
-                available_releases,
-                ..
-            }
-            | CertificationStatusResponse::CertifiedImageExists {
-                certified_url,
-                architecture,
-                bios,
-                board,
-                available_releases,
-                ..
-            } => (certified_url, architecture, bios, board, available_releases),
-            _ => panic!(
-                "Expected response to be Certified or Certified Image Exists, but it was {:?}",
-                response
-            ),
-        };
-
-    let (expected_certified_url, expected_arch, expected_bios, expected_board, expected_releases) =
-        match expected {
-            CertificationStatusResponse::Certified {
-                certified_url,
-                architecture,
-                bios,
-                board,
-                available_releases,
-                ..
-            }
-            | CertificationStatusResponse::CertifiedImageExists {
-                certified_url,
-                architecture,
-                bios,
-                board,
-                available_releases,
-                ..
-            } => (certified_url, architecture, bios, board, available_releases),
-            _ => panic!("Expected response must contain Certified or CertifiedImageExists status"),
-        };
+    let (status, certified_url, available_releases) = response.get_status();
+    let (expected_status, expected_certified_url, expected_available_releases) = expected.get_status();
 
     assert_eq!(
-        actual_certified_url, expected_certified_url,
+        status, expected_status,
+        "Certification status mismatch"
+    );
+    assert_eq!(
+        certified_url, expected_certified_url,
         "Certified URL mismatch"
     );
-    assert_eq!(actual_arch, expected_arch, "Architecture mismatch");
-    assert_eq!(actual_bios, expected_bios, "BIOS mismatch");
-    assert_eq!(actual_board, expected_board, "Board mismatch");
     assert_eq!(
-        actual_releases, expected_releases,
+        available_releases, expected_available_releases,
         "Available releases mismatch"
     );
 }
@@ -117,7 +77,7 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
     let api_url = std::env::var("API_URL").expect("API_URL environment variable must be specified");
 
     let cert_request = CertificationStatusRequest::new(get_test_device_paths(dir_path))?;
-    let response = check_certification_status(api_url, hwlib::CheckCertificationMode::Force, &cert_request, None)?;
+    let response = check_certification_status(api_url, hwlib::CheckCertificationMode::Forced, &cert_request, None)?;
 
     let response_json_file = PathBuf::from("/app/client/test_data")
         .join(dir_path)
@@ -130,13 +90,13 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
 
 #[test]
 fn test_server_connection_error() -> Result<()> {
-    let result = check_certification_status(
+    let result: Result<PublicCertificationStatus> = check_certification_status(
         "http://non-existent-server:8080".to_string(),
-        hwlib::CheckCertificationMode::Force,
+        hwlib::CheckCertificationMode::Forced,
         &CertificationStatusRequest::new(get_test_device_paths("amd64/dell_xps13"))?,
-        None,
-    );
+        None);
 
-    assert!(result.is_err());
+    let (staled, _) = result.unwrap().is_staled();
+    assert!(staled); // we are expecting a stale response due to server connection error
     Ok(())
 }

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -117,7 +117,7 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
     let api_url = std::env::var("API_URL").expect("API_URL environment variable must be specified");
 
     let cert_request = CertificationStatusRequest::new(get_test_device_paths(dir_path))?;
-    let response = send_certification_status_request(api_url, &cert_request)?;
+    let response = check_certification_status(api_url, hwlib::CheckCertificationMode::Force, &cert_request, None)?;
 
     let response_json_file = PathBuf::from("/app/client/test_data")
         .join(dir_path)
@@ -130,9 +130,11 @@ fn test_certification_request(dir_path: &str) -> Result<()> {
 
 #[test]
 fn test_server_connection_error() -> Result<()> {
-    let result = send_certification_status_request(
+    let result = check_certification_status(
         "http://non-existent-server:8080".to_string(),
+        hwlib::CheckCertificationMode::Force,
         &CertificationStatusRequest::new(get_test_device_paths("amd64/dell_xps13"))?,
+        None,
     );
 
     assert!(result.is_err());

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -20,7 +20,6 @@ use anyhow::Result;
 use hwlib::{
     models::request_validators::{CertificationStatusRequest, Paths},
     models::response_validators::CertificationStatusResponse,
-    send_certification_status_request,
 };
 use simple_test_case::test_case;
 use std::{

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -96,7 +96,7 @@ fn test_server_connection_error() -> Result<()> {
         &CertificationStatusRequest::new(get_test_device_paths("amd64/dell_xps13"))?,
         None);
 
-    let (staled, _) = result.unwrap().is_staled();
+    let (staled, _) = result.is_staled();
     assert!(staled); // we are expecting a stale response due to server connection error
     Ok(())
 }

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -96,7 +96,7 @@ fn test_server_connection_error() -> Result<()> {
         &CertificationStatusRequest::new(get_test_device_paths("amd64/dell_xps13"))?,
         None);
 
-    let (staled, _, _) = result.get_status();
+    let (staled, _) = result.stale_status();
     assert!(staled); // we are expecting a stale response due to server connection error
     Ok(())
 }

--- a/integration-tests/src/integration_test.rs
+++ b/integration-tests/src/integration_test.rs
@@ -96,7 +96,7 @@ fn test_server_connection_error() -> Result<()> {
         &CertificationStatusRequest::new(get_test_device_paths("amd64/dell_xps13"))?,
         None);
 
-    let (staled, _) = result.is_staled();
+    let (staled, _) = result.get_status();
     assert!(staled); // we are expecting a stale response due to server connection error
     Ok(())
 }


### PR DESCRIPTION
This PR adds a cache to preserve the latest state, and defines the cases where the cache has to be invalidated and the Certification Status must be requested again.

By default, the cache is stored at $SNAP_DATA, since the idea is to go full-snap.

<!-- Describe the tests you ran to verify your changes. -->

- Unit tests
- Manual testing steps:

Built it and tested both "as-is" and with "sudo", both without parameters and with a wrong "--server" parameter. The first one returned, as expected, an error because it can't collect the data. The second succeeds. The third fails, as expected, with an error because the server doesn't return the expected data format.

Now it always returns a JSON through STDOUT, but if there is an error, it will also return it through STDERR as before.

## Checklist

Still require more unitary tests.

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [X] I have added necessary tests.
- [ ] I have added or updated any relevant documentation (if needed).
- [X] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
