### PR TITLE
fix(ci): specify self-hosted runner label

### DIFF
--- a/.github/workflows/openapi_gh_pages.yaml
+++ b/.github/workflows/openapi_gh_pages.yaml
@@ -20,7 +20,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [self-hosted, linux, large, noble, x64]
+    runs-on: self-hosted-linux-amd64-noble-large
     defaults:
       run:
         working-directory: server

--- a/.github/workflows/package_client.yaml
+++ b/.github/workflows/package_client.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   snap:
     name: Snap
-    runs-on: [self-hosted, linux, jammy, x64]
+    runs-on: self-hosted-linux-amd64-jammy-medium
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/promote_snap.yaml
+++ b/.github/workflows/promote_snap.yaml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   promote:
     name: Promote Snap
-    runs-on: [self-hosted, linux, jammy, x64]
+    runs-on: self-hosted-linux-amd64-jammy-medium
     permissions:
       contents: read
     env:

--- a/.github/workflows/publish_client_crates.yaml
+++ b/.github/workflows/publish_client_crates.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   publish:
     name: Publish hwlib to crates.io
-    runs-on: [self-hosted, linux, large, noble, x64]
+    runs-on: self-hosted-linux-amd64-noble-large
     environment: release
     permissions:
       id-token: write # Required by the trusted auth

--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   build-and-push-image:
     name: Build and push Docker image
-    runs-on: [self-hosted, linux, jammy, x64]
+    runs-on: self-hosted-linux-amd64-jammy-medium
     permissions:
       contents: read # necessary to pull repository
       packages: write # necessary to push image to ghcr
@@ -57,7 +57,7 @@ jobs:
 
   build-and-push-charm:
     name: Build and push charm
-    runs-on: [self-hosted, linux, xlarge, jammy, x64]
+    runs-on: self-hosted-linux-amd64-jammy-xlarge
     needs: build-and-push-image
     permissions:
       contents: write # necessary to create tag

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test:
     name: Run integration tests
-    runs-on: [self-hosted, linux, large, noble, x64]
+    runs-on: self-hosted-linux-amd64-noble-large
     defaults:
       run:
         working-directory: integration-tests

--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-and-test:
     name: Lint and test client
-    runs-on: [self-hosted, linux, large, noble, x64]
+    runs-on: self-hosted-linux-amd64-noble-large
     defaults:
       run:
         working-directory: client
@@ -60,7 +60,7 @@ jobs:
 
   py-bindings-test:
     name: Test Python bindings
-    runs-on: [self-hosted, linux, large, noble, x64]
+    runs-on: self-hosted-linux-amd64-noble-large
     defaults:
       run:
         working-directory: client

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     name: Test server
-    runs-on: [self-hosted, linux, large, noble, x64]
+    runs-on: self-hosted-linux-amd64-noble-large
     defaults:
       run:
         working-directory: server
@@ -141,7 +141,7 @@ jobs:
 
   charm-integration:
     name: Test Charm (integration)
-    runs-on: [self-hosted, linux, large, noble, amd64]
+    runs-on: self-hosted-linux-amd64-noble-large
     defaults:
       run:
         working-directory: server/charm


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR pins the self-hosted runner labels to avoid using private-endpoint runners (which do not work in forked PRs)

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->


## Testing

<!-- Describe the tests you ran to verify your changes. -->

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [X] I have added necessary tests.
- [X] I have added or updated any relevant documentation (if needed).
- [X] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
