### PR TITLE
breaking(terraform): update charm and product modules with juju 2.0 provider

### DIFF
--- a/server/terraform/charm/README.md
+++ b/server/terraform/charm/README.md
@@ -56,13 +56,13 @@ The complete list of available integrations can be found
 
 | Name                  | Version   |
 | --------------------- | --------- |
-| [juju][juju-provider] | ~> 0.17.0 |
+| [juju][juju-provider] | ~> 2.0 |
 
 ## Providers
 
 | Name                  | Version   |
 | --------------------- | --------- |
-| [juju][juju-provider] | ~> 0.17.0 |
+| [juju][juju-provider] | ~> 2.0 |
 
 ## Modules
 

--- a/server/terraform/charm/main.tf
+++ b/server/terraform/charm/main.tf
@@ -1,6 +1,10 @@
 resource "juju_application" "hardware_api" {
-  name  = var.app_name
-  model = var.model
+  name        = var.app_name
+  model_uuid  = var.model_uuid
+  constraints = var.constraints
+  config      = var.config
+  units       = var.units
+
 
   charm {
     name     = "hardware-api"
@@ -8,8 +12,4 @@ resource "juju_application" "hardware_api" {
     channel  = var.channel
     revision = var.revision
   }
-
-  config      = var.config
-  constraints = var.constraints
-  units       = var.units
 }

--- a/server/terraform/charm/outputs.tf
+++ b/server/terraform/charm/outputs.tf
@@ -1,10 +1,10 @@
-output "app_name" {
+output "application" {
   description = "Name of the deployed application"
-  value       = juju_application.hardware_api.name
+  value       = juju_application.hardware_api
 }
 
-output "endpoints" {
-  description = "Map of all endpoints"
+output "requires" {
+  description = "Map of requires integration endpoints"
   value = {
     nginx_route = "nginx-route"
     ingress     = "ingress"

--- a/server/terraform/charm/terraform.tf
+++ b/server/terraform/charm/terraform.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.17.0"
+      version = "~> 2.0"
       source  = "juju/juju"
     }
   }

--- a/server/terraform/charm/variables.tf
+++ b/server/terraform/charm/variables.tf
@@ -25,15 +25,14 @@ variable "config" {
 
 variable "constraints" {
   type        = string
-  default     = "arch=amd64"
+  nullable    = true
+  default     = null
   description = "String listing constraints for this application"
 }
 
-variable "model" {
+variable "model_uuid" {
   type        = string
-  nullable    = true
-  default     = null
-  description = "Reference to an existing model resource or data source for the model to deploy to"
+  description = "Reference to an existing model uuid"
 }
 
 variable "revision" {

--- a/server/terraform/product/main.tf
+++ b/server/terraform/product/main.tf
@@ -1,5 +1,6 @@
 data "juju_model" "hardware_api" {
-  name = var.model
+  name  = var.model
+  owner = var.owner
 }
 
 module "hardware_api" {
@@ -7,34 +8,46 @@ module "hardware_api" {
   app_name    = var.hardware_api.app_name
   channel     = var.hardware_api.channel
   config      = var.hardware_api.config
-  model       = data.juju_model.hardware_api.name
+  model_uuid  = data.juju_model.hardware_api.uuid
   constraints = var.hardware_api.constraints
   revision    = var.hardware_api.revision
   base        = var.hardware_api.base
   units       = var.hardware_api.units
 }
 
-resource "juju_application" "nginx_ingress_integrator" {
-  name  = var.nginx_ingress_integrator.app_name
-  model = data.juju_model.hardware_api.name
-  trust = true
+resource "juju_application" "ingress_configurator" {
+  name       = var.ingress_configurator.app_name
+  model_uuid = data.juju_model.hardware_api.uuid
+  trust      = true
   charm {
-    name     = "nginx-ingress-integrator"
-    channel  = var.nginx_ingress_integrator.channel
-    revision = var.nginx_ingress_integrator.revision
+    name     = "ingress-configurator"
+    channel  = var.ingress_configurator.channel
+    revision = var.ingress_configurator.revision
   }
-  units  = var.nginx_ingress_integrator.units
-  config = var.nginx_ingress_integrator.config
+  units  = var.ingress_configurator.units
+  config = var.ingress_configurator.config
 }
 
 resource "juju_integration" "hardware_api_ingress" {
-  model = data.juju_model.hardware_api.name
+  model_uuid = data.juju_model.hardware_api.uuid
   application {
-    name     = module.hardware_api.app_name
-    endpoint = module.hardware_api.endpoints.nginx_route
+    name     = module.hardware_api.application.name
+    endpoint = module.hardware_api.requires.ingress
   }
   application {
-    name     = juju_application.nginx_ingress_integrator.name
-    endpoint = "nginx-route"
+    name     = juju_application.ingress_configurator.name
+    endpoint = "ingress"
+  }
+}
+
+resource "juju_integration" "ingress_configurator_haproxy" {
+  count      = var.haproxy_offer != null ? 1 : 0
+  model_uuid = data.juju_model.hardware_api.uuid
+  application {
+    name     = juju_application.ingress_configurator.name
+    endpoint = "haproxy-route"
+  }
+  application {
+    offer_url = var.haproxy_offer
   }
 }

--- a/server/terraform/product/outputs.tf
+++ b/server/terraform/product/outputs.tf
@@ -1,29 +1,12 @@
-output "hardware_api_app_name" {
-  description = "The name of the Hardware API application"
-  value       = module.hardware_api.app_name
-}
-
-output "hardware_api_requires" {
+output "models" {
+  description = "Map of the key of the model and the components deployed in the model"
   value = {
-    nginx_route = "nginx-route"
-  }
-}
-
-output "hardware_api_provides" {
-  value = {}
-}
-
-output "nginx_ingress_integrator_app_name" {
-  description = "The name of the NGINX Ingress Integrator application"
-  value       = juju_application.nginx_ingress_integrator.name
-}
-
-output "nginx_ingress_integrator_requires" {
-  value = {}
-}
-
-output "nginx_ingress_integrator_provides" {
-  value = {
-    nginx_route = "nginx-route"
+    hardware_api = {
+      model_uuid = data.juju_model.hardware_api.uuid
+      components = {
+        hardware_api         = module.hardware_api.application
+        ingress_configurator = juju_application.ingress_configurator
+      }
+    }
   }
 }

--- a/server/terraform/product/terraform.tf
+++ b/server/terraform/product/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.17.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/server/terraform/product/variables.tf
+++ b/server/terraform/product/variables.tf
@@ -1,8 +1,12 @@
 variable "model" {
   type        = string
-  nullable    = true
-  default     = null
   description = "Reference to an existing model resource or data source for the model to deploy to"
+}
+
+variable "owner" {
+  type        = string
+  default     = null
+  description = "Reference to the owner of the model to deploy to"
 }
 
 variable "hardware_api" {
@@ -15,14 +19,24 @@ variable "hardware_api" {
     base        = optional(string, "ubuntu@22.04")
     units       = optional(number, 1)
   })
+  default = {}
 }
 
-variable "nginx_ingress_integrator" {
+variable "ingress_configurator" {
   type = object({
-    app_name = optional(string, "ingress")
-    channel  = optional(string, "latest/stable")
+    app_name = optional(string, "ingress-configurator")
+    channel  = optional(string, "latest/edge")
     config   = optional(map(string), {})
     revision = optional(number)
     units    = optional(number, 1)
   })
+  default = {}
 }
+
+variable "haproxy_offer" {
+  type        = string
+  nullable    = true
+  default     = null
+  description = "URL to the haproxy offer for ingress relation. If null, the integration is not created."
+}
+


### PR DESCRIPTION
## Description
This PR bumps the juju provider version to 2.0.
As part of this bump, this also:
1. align terraform/charm module with the expectations from [CC008](https://docs.google.com/document/d/1k1psLCfcf0Nr5KeVtWGFi9wmzhcg5AP9GVZTsRyVQSQ/edit?tab=t.0) (specifically the use of `model_uuid` instead of model name"
2. update terraform/product module based on previous changes. It also moves from nginx to ingress-configurator + haproxy. Similarly, it also aligns to the Spec. 
<!-- Please include a summary of the changes and the motivation behind them. -->

## Related Issue(s)
<!-- If this PR addresses an issue, link it here. -->
NA

## Testing

<!-- Describe the tests you ran to verify your changes. -->
Manual testing steps:

  1. Created multipass environment and then, from the product module run terraform plan:
```
Terraform will perform the following actions:

  # juju_application.ingress_configurator will be created
  + resource "juju_application" "ingress_configurator" {
      + config      = {}
      + constraints = (known after apply)
      + id          = (known after apply)
      + machines    = (known after apply)
      + model_type  = (known after apply)
      + model_uuid  = "2f4de55d-09f1-44ce-8c78-305c7fe7d1e6"
      + name        = "ingress-configurator"
      + storage     = (known after apply)
      + trust       = true
      + units       = 1

      + charm {
          + base     = (known after apply)
          + channel  = "latest/edge"
          + name     = "ingress-configurator"
          + revision = (known after apply)
        }
    }

  # juju_integration.hardware_api_ingress will be created
  + resource "juju_integration" "hardware_api_ingress" {
      + id         = (known after apply)
      + model_uuid = "2f4de55d-09f1-44ce-8c78-305c7fe7d1e6"

      + application {
          + endpoint = "ingress"
          + name     = "api"
        }
      + application {
          + endpoint = "ingress"
          + name     = "ingress-configurator"
        }
    }

  # module.hardware_api.juju_application.hardware_api will be created
  + resource "juju_application" "hardware_api" {
      + config      = {}
      + constraints = "arch=amd64"
      + id          = (known after apply)
      + machines    = (known after apply)
      + model_type  = (known after apply)
      + model_uuid  = "2f4de55d-09f1-44ce-8c78-305c7fe7d1e6"
      + name        = "api"
      + storage     = (known after apply)
      + trust       = false
      + units       = 1

      + charm {
          + base     = "ubuntu@22.04"
          + channel  = "latest/edge"
          + name     = "hardware-api"
          + revision = (known after apply)
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```
  2. Run terraform apply
  3. Wait for changes to be deployed:
```
juju status --relations
Model      Controller                    Cloud/Region        Version  SLA          Timestamp
hwapi-dev  my-first-microk8s-controller  microk8s/localhost  3.6.24   unsupported  12:42:59-06:00

App                   Version  Status   Scale  Charm                 Channel      Rev  Address         Exposed  Message
api                            active       1  hardware-api          latest/edge  169  10.152.183.185  no       
ingress-configurator           blocked      1  ingress-configurator  latest/edge   87  10.152.183.56   no       Route relation required.

Unit                     Workload  Agent  Address      Ports  Message
api/0*                   active    idle   10.1.158.9          
ingress-configurator/0*  blocked   idle   10.1.158.10         Route relation required.

Integration provider          Requirer     Interface  Type     Message
ingress-configurator:ingress  api:ingress  ingress    regular  
```

> [!NOTE]
This is waiting for haproxy route but I did not deploy the charm. the var.haproxy_offer needs to be properly defined 
## Checklist

<!-- Make sure your PR meets these requirements. -->

- [x] I have followed the [contribution guidelines].
- [x] I have signed the [Canonical CLA][cla].
- [ ] I have added necessary tests.
- [x] I have added or updated any relevant documentation (if needed).
- [x] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
