### PR TITLE
Move snapcraft.yaml file to the root folder

### DIFF
--- a/.github/workflows/package_client.yaml
+++ b/.github/workflows/package_client.yaml
@@ -42,7 +42,7 @@ jobs:
         id: snapcraft
         uses: canonical/snapcraft-multiarch-action@0c3495a6cead8eeacc35e1254fee7d2381e550e4 # v1.10.1
         with:
-          path: client
+          path: .
           architecture: ${{ matrix.arch }}
       - name: Upload snapcraft logs
         if: failure()

--- a/client/CONTRIBUTING.md
+++ b/client/CONTRIBUTING.md
@@ -12,7 +12,7 @@ refer to the [contribution guide](../CONTRIBUTING.md).
 ## Snap Package
 
 `hwctl` is packaged as a [snap]. To build the snap package locally, install
-[`snapcraft`][snapcraft] and run the following command:
+[`snapcraft`][snapcraft] and run the following command in the repository top folder:
 
 ```shell
 snapcraft pack
@@ -27,7 +27,7 @@ sudo snap install --dangerous hwctl_<version>_<architecture>.snap
 # The following interfaces are required to run the snap package
 # They are not automatically connected when installing a local package
 sudo snap connect hwctl:hardware-observe
-sudo snap connect hwctl:kenrel-module-observe
+sudo snap connect hwctl:kernel-module-observe
 sudo snap connect hwctl:system-observe
 ```
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
   hwctl:
     plugin: rust
     rust-features: ["cli"]
-    source: .
+    source: client/.
     build-packages:
       - jq
       - libssl-dev


### PR DESCRIPTION
This allows to build the snap directly from the root, and thus not needing to specify a directory. This is useful for launchpad recipes and for building the snap directly from the snap store.
