### PR TITLE
feat: add --verbosity flag to hwctl CLI

### DIFF
--- a/client/bin/hwctl.rs
+++ b/client/bin/hwctl.rs
@@ -18,7 +18,8 @@
  */
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+use std::fmt;
 use std::process::ExitCode;
 
 use hwlib::models::request_validators::{CertificationStatusRequest, Paths};
@@ -44,11 +45,45 @@ struct Args {
         help = "API server URL"
     )]
     hw_api_url: String,
+
+    #[arg(
+        long,
+        default_value_t = Verbosity::Brief,
+        value_enum,
+        value_name = "LEVEL",
+        help = "Output verbosity level"
+    )]
+    verbosity: Verbosity,
+
+    #[arg(long, help = "Shorthand for --verbosity=verbose")]
+    verbose: bool,
+}
+
+#[derive(ValueEnum, Clone, Debug, Default, PartialEq)]
+#[value(rename_all = "lowercase")]
+enum Verbosity {
+    #[default]
+    Brief,
+    Verbose,
+}
+
+impl fmt::Display for Verbosity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Verbosity::Brief => write!(f, "brief"),
+            Verbosity::Verbose => write!(f, "verbose"),
+        }
+    }
 }
 
 fn main() -> ExitCode {
     let args = Args::parse();
-    match run(args.hw_api_url) {
+    let verbosity = if args.verbose {
+        Verbosity::Verbose
+    } else {
+        args.verbosity
+    };
+    match run(args.hw_api_url, verbosity) {
         Ok(_) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("ERROR: {e:?}");
@@ -57,11 +92,22 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(server_url: String) -> Result<()> {
+fn run(server_url: String, verbosity: Verbosity) -> Result<()> {
+    if verbosity == Verbosity::Verbose {
+        eprintln!("Collecting system data...");
+    }
     let cert_status_request =
         CertificationStatusRequest::new(Paths::default()).context("cannot collect system data")?;
+
+    if verbosity == Verbosity::Verbose {
+        eprintln!("Sending request to {}...", server_url);
+    }
     let response = send_certification_status_request(server_url, &cert_status_request)
         .context("cannot send certification status request")?;
+
+    if verbosity == Verbosity::Verbose {
+        eprintln!("Response received.");
+    }
     let response_json =
         serde_json::to_string_pretty(&response).context("cannot serialize response as JSON")?;
     println!("{response_json}");


### PR DESCRIPTION
## Description

Adds `--verbosity=<level>` and `--verbose` flags to the `hwctl` CLI, as
requested in #557, aligning with Canonical CLI standards.

- `--verbosity=brief` (default): current behaviour, no change to stdout output
- `--verbosity=verbose` / `--verbose`: prints progress steps to **stderr**
  as hwctl runs (`Collecting system data...`, `Sending request to <url>...`,
  `Response received.`), keeping stdout clean for piping/scripting

`trace` is intentionally excluded from this PR (see maintainer note in #557
about root-only data concerns).

Implementation details:
- `Verbosity` enum derives `clap::ValueEnum` so clap handles validation and
  help text automatically
- Verbose messages use `eprintln!` (stderr) so stdout remains the structured
  JSON output regardless of verbosity level
- `--verbose` is a convenience shorthand that overrides `--verbosity` in code

## Related Issue(s)

Closes #557

## Testing

- Unit tests: `cargo test` (no existing tests broken; no new unit tests needed
  for CLI flag parsing — clap covers that internally)
- Manual testing steps:

  1. `cargo build --features cli`
  2. Default (brief): `sudo ./target/debug/hwctl` — output unchanged, no extra lines
  3. Long flag: `sudo ./target/debug/hwctl --verbosity=verbose` — three progress
     lines appear on stderr before the JSON response
  4. Short flag: `sudo ./target/debug/hwctl --verbose` — same as step 3
  5. Piping: `sudo ./target/debug/hwctl --verbose 2>/dev/null` — only JSON on
     stdout, confirming verbose output is on stderr

## Checklist

- [x] I have followed the [contribution guidelines].
- [x] I have signed the [Canonical CLA][cla].
- [x] I have added necessary tests.
- [x] I have added or updated any relevant documentation (if needed).
- [x] I have tested the changes.

## Additional Notes

`trace` level (showing request/response bodies) is left for a follow-up issue
once the maintainer team has resolved the security considerations around
root-only collected data.

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
