### PR TITLE
ci: use mostly github-hosted runners

### DIFF
--- a/.github/workflows/openapi_gh_pages.yaml
+++ b/.github/workflows/openapi_gh_pages.yaml
@@ -20,7 +20,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: self-hosted-linux-amd64-noble-large
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: server

--- a/.github/workflows/publish_client_crates.yaml
+++ b/.github/workflows/publish_client_crates.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   publish:
     name: Publish hwlib to crates.io
-    runs-on: self-hosted-linux-amd64-noble-large
+    runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write # Required by the trusted auth

--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -57,7 +57,7 @@ jobs:
 
   build-and-push-charm:
     name: Build and push charm
-    runs-on: self-hosted-linux-amd64-jammy-xlarge
+    runs-on: ubuntu-latest
     needs: build-and-push-image
     permissions:
       contents: write # necessary to create tag


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR moves most of the workflows to use GitHub-hosted runners
- the only job that can't be migrated is the docker build, since the image is larger than the GitHub hosted runner disk size

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->

## Testing

<!-- Describe the tests you ran to verify your changes. -->

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [ ] I have added necessary tests.
- [ ] I have added or updated any relevant documentation (if needed).
- [ ] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
