### PR TITLE
Fix cache permissions

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -33,6 +33,14 @@ the `--server` command line parameter:
 hwctl --server https://your.server.url
 ```
 
+An important detail is that this option is, by default, disabled in the
+snap version for security reasons. To enable it, just set the
+`allow-custom-url` setting to `true` in the `hwctl` snap with:
+
+```shell
+sudo snap set hwctl allow-custom-url=true
+```
+
 You can specify whether you want to get the currently cached data, to
 force a refresh from the server, or to let the application to decide
 (return cached data if there are valid cached values, or get them from

--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -139,11 +139,15 @@ impl HWCache {
     }
 
     fn save(&self) {
-        let config = File::create(self.cache_path.clone());
-        if config.is_err() {
+        let cache = File::create(self.cache_path.clone());
+        if cache.is_err() {
             return;
         }
-        let _ = serde_json::to_writer_pretty(config.unwrap(), &self.data);
+        let _ = serde_json::to_writer_pretty(cache.unwrap(), &self.data);
+        let _ = std::fs::set_permissions(
+            self.cache_path.clone(),
+            std::os::unix::fs::PermissionsExt::from_mode(0o600),
+        );
         let config = File::create(self.settings_path.clone());
         if config.is_err() {
             return;


### PR DESCRIPTION
The cache must have o600 permissions, to ensure that no one can read the cached data. Unfortunately, this wasn't being done.

This patch fixes this, and also adds in the README the info about how to enable using custom URLs for the server.

## Testing

Installed the patched version, launched `hwctl`, and checked the permissions for `/var/snap/hwctl/current/hw_cache.json` file,
to ensure that only the owner could read and write it, while all the rest of the users can't neither read nor write.

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [X] I have added necessary tests.
- [X] I have added or updated any relevant documentation (if needed).
- [X] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
