### PR TITLE
fix(ci): upload-charm action needs same os as base

### DIFF
--- a/.github/workflows/publish_server.yaml
+++ b/.github/workflows/publish_server.yaml
@@ -59,7 +59,7 @@ jobs:
 
   build-and-push-charm:
     name: Build and push charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-and-push-image
     permissions:
       contents: write # necessary to create tag


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

- This PR fixes the server publish CI by pinning the runner to the same OS as the charm base (charm CI uses destructive mode)

## Related Issue(s)

<!-- If this PR addresses an issue, link it here. -->

## Testing

<!-- Describe the tests you ran to verify your changes. -->

## Checklist

<!-- Make sure your PR meets these requirements. -->

- [X] I have followed the [contribution guidelines].
- [X] I have signed the [Canonical CLA][cla].
- [ ] I have added necessary tests.
- [ ] I have added or updated any relevant documentation (if needed).
- [ ] I have tested the changes.

## Additional Notes

<!-- Any additional information, concerns, or questions for the reviewers -->

[contribution guidelines]: https://github.com/canonical/hardware-api/blob/main/CONTRIBUTING.md
[cla]: https://ubuntu.com/legal/contributors
